### PR TITLE
Add copilot instructions and begin migrating off tailwind css

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,49 @@
+Purpose
+-------
+These instructions tell GitHub Copilot how to handle styling and CSS when generating or modifying UI, templates, HTML, and static assets for this repository.
+
+Key rule (always)
+-----------------
+- Always use the repository's canonical stylesheet located at `internal/server/public/styles/site.css` for site-specific styling.
+- When adding or changing styles for the application UI, prefer adding new rules to `internal/server/public/styles/site.css` instead of creating new top-level CSS files or embedding inline styles.
+
+When generating HTML/templates/components
+----------------------------------------
+- Ensure the page or template links to the served stylesheet. Use the public path `/styles/site.css` (this file is stored in the repo at `internal/server/public/styles/site.css`). Example HTML head snippet:
+
+	<link rel="stylesheet" href="/styles/site.css">
+
+- Prefer applying CSS classes that already exist in `site.css`. If a needed utility/class is missing, add it to `site.css` with a clear name and comment, and then use it in the markup.
+
+Avoid
+-----
+- Do not add inline styles (style="...") for persistent UI design. Small one-off debug styles are allowed in development but should be moved into `site.css` before merging.
+- Do not introduce new global stylesheets at the project root. Keep site-wide styles centralized in `internal/server/public/styles/site.css`.
+
+Style additions best practices
+-----------------------------
+- Keep new selectors specific and prefixed if needed to avoid collisions (e.g., .ab- or .site-).
+- Add a short comment above any new section in `site.css` describing its purpose and where it's used.
+- When changing existing styles, search for usages in `internal/server/ui/` and other templates to avoid regressions.
+
+Notes for Tailwind or other utilities
+-----------------------------------
+- This repository includes `tailwind.config.js`. When generating utility classes that are Tailwind-based, prefer using the existing Tailwind setup for utility-style needs, but still centralize site overrides and component-level custom CSS in `internal/server/public/styles/site.css`.
+
+If you cannot follow the rule
+---------------------------
+- If a generated change absolutely requires a separate stylesheet (e.g., for a large, self-contained third-party bundle), add a short rationale in the PR description and keep it scoped to the feature directory. Prefer linking to and documenting that stylesheet in `internal/server/public/README.md`.
+
+Files
+-----
+- Canonical stylesheet (source): `internal/server/public/styles/site.css`
+- When linking from templates use: `/styles/site.css`
+
+Example (Go template head)
+--------------------------
+{{`<head>`}}
+	{{`<meta charset="utf-8">`}}
+	{{`<meta name="viewport" content="width=device-width,initial-scale=1">`}}
+	{{`<link rel="stylesheet" href="/styles/site.css">`}}
+{{`</head>`}}
+

--- a/internal/server/public/styles/site.css
+++ b/internal/server/public/styles/site.css
@@ -1,0 +1,65 @@
+/*
+	Canonical site stylesheet
+	Moved styles from: internal/server/ui/components/body/component.templ
+	Purpose: Centralize global UI rules (prefer using Tailwind utilities in components,
+	but keep site-wide overrides and dark-mode rules here per project convention).
+*/
+
+/* Body background: replicate Tailwind's
+	 bg-gradient-to-br from-gray-400 dark:from-gray-900 dark:to-gray-800 */
+.site-body {
+	/* light mode fallback */
+	--site-from: #9CA3AF; /* gray-400 */
+	--site-to: rgba(255,255,255,0); /* transparent-ish */
+	background: linear-gradient(135deg, var(--site-from) 0%, var(--site-to) 100%);
+	min-height: 100vh;
+}
+
+@media (prefers-color-scheme: dark) {
+	.site-body {
+		--site-from: #111827; /* gray-900 */
+		--site-to: #1f2937;   /* gray-800 */
+		color-scheme: dark;
+	}
+}
+
+/* Main text color that switches with dark mode (maps to text-black dark:text-white) */
+.site-main {
+	color: #000;
+}
+
+@media (prefers-color-scheme: dark) {
+	.site-main {
+		color: #fff;
+	}
+}
+
+/* Small utility to preserve the original layout intent from the template */
+.site-fullscreen-col {
+	max-height: 100vh;
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+
+/* End of moved rules */
+
+/* Global resets moved from header template */
+html, body {
+	margin: 0;
+	padding: 0;
+	min-height: 100vh;
+	min-width: 100vw;
+	overflow-x: hidden;
+}
+
+* {
+	margin: 0;
+	padding: 0;
+	box-sizing: border-box;
+}
+
+/* Hide default file input button; components should provide a styled label */
+input[type=file]::file-selector-button {
+	display: none;
+}

--- a/internal/server/ui/components/body/component.templ
+++ b/internal/server/ui/components/body/component.templ
@@ -7,10 +7,10 @@ import (
 )
 
 templ Component(pageState types.PageState) {
-	<body class="bg-gradient-to-br from-gray-400 dark:from-gray-900 dark:to-gray-800">
-		<main class="text-black dark:text-white">
+	<body class="site-body">
+		<main class="site-main">
 			@gradient_overlays.Component()
-			<div class="max-h-screen min-h-screen flex flex-col">
+			<div class="site-fullscreen-col">
 				@topnav.Component(pageState)
 				{ children... }
 			</div>

--- a/internal/server/ui/components/body/component_templ.go
+++ b/internal/server/ui/components/body/component_templ.go
@@ -35,7 +35,7 @@ func Component(pageState types.PageState) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<body class=\"bg-gradient-to-br from-gray-400 dark:from-gray-900 dark:to-gray-800\"><main class=\"text-black dark:text-white\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<body class=\"site-body\"><main class=\"site-main\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -43,7 +43,7 @@ func Component(pageState types.PageState) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"max-h-screen min-h-screen flex flex-col\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"site-fullscreen-col\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/server/ui/components/header/component.templ
+++ b/internal/server/ui/components/header/component.templ
@@ -8,24 +8,6 @@ templ Component() {
 		<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
 		<title>Autobutler - Your home assistant</title>
 		<link rel="icon" type="image/x-icon" href="/public/favicons/48x48.ico"/>
-		<style>
-            html, body {
-                margin: 0;
-                padding: 0;
-                min-height: 100vh;
-                min-width: 100vw;
-                overflow-x: hidden;
-            }
-
-            * {
-                margin: 0;
-                padding: 0;
-                box-sizing: border-box;
-            }
-
-            input[type=file]::file-selector-button {
-                display: none;
-            }
-        </style>
+		<link rel="stylesheet" href="/public/styles/site.css" type="text/css"/>
 	</head>
 }

--- a/internal/server/ui/components/header/component_templ.go
+++ b/internal/server/ui/components/header/component_templ.go
@@ -29,7 +29,7 @@ func Component() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<head><script src=\"/public/vendor/tailwind/tailwind.3.4.16.js\"></script><script src=\"/public/vendor/htmx/htmx.min.js\"></script><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Autobutler - Your home assistant</title><link rel=\"icon\" type=\"image/x-icon\" href=\"/public/favicons/48x48.ico\"><style>\n            html, body {\n                margin: 0;\n                padding: 0;\n                min-height: 100vh;\n                min-width: 100vw;\n                overflow-x: hidden;\n            }\n\n            * {\n                margin: 0;\n                padding: 0;\n                box-sizing: border-box;\n            }\n\n            input[type=file]::file-selector-button {\n                display: none;\n            }\n        </style></head>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<head><script src=\"/public/vendor/tailwind/tailwind.3.4.16.js\"></script><script src=\"/public/vendor/htmx/htmx.min.js\"></script><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><title>Autobutler - Your home assistant</title><link rel=\"icon\" type=\"image/x-icon\" href=\"/public/favicons/48x48.ico\"><link rel=\"stylesheet\" href=\"/public/styles/site.css\" type=\"text/css\"></head>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Basically just adding copilot-instructions.md and begin migrating off of tailwind css into a site.css instead.