### PR TITLE
Remove margin, border-radius, padding, and border from file-explorer class.

### DIFF
--- a/internal/server/public/styles/file-explorer.css
+++ b/internal/server/public/styles/file-explorer.css
@@ -7,11 +7,8 @@
 .file-explorer {
     background-color: white;
     max-width: 100%;
-    margin: var(--spacing-2xl) var(--spacing-xl);
-    border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-sm);
-    padding: var(--spacing-xl);
-    border: 1px solid var(--color-gray-200);
+    padding: var(--spacing-lg);
     flex: 1;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Explanation
The file explorer is wrapped in a large amount of margin that unnecessarily limits available screen real-estate. This PR removes that margin and subsequently removes border properties that would now look strange without the margin. This PR additionally decreases the padding of the file explorer for similar reasons aforementioned.

## Before
<img width="3252" height="2116" alt="before" src="https://github.com/user-attachments/assets/a644b401-7d0b-4bb9-b0a0-2e3b66d69142" />

## After
<img width="3252" height="2116" alt="after" src="https://github.com/user-attachments/assets/c55262e5-a900-467b-b218-c73fdee7ffd0" />