### PR TITLE
Allow for UI to manage files on non-root devices

### DIFF
--- a/app/src/components/cirrus/CirrusFileExplorer.vue
+++ b/app/src/components/cirrus/CirrusFileExplorer.vue
@@ -380,8 +380,19 @@ const submitMoveDialog = async () => {
       moveDialogOldDeviceName.value,
       moveDialogOldDeviceName.value,
     )
-    // Update UI: refetch files and close dialog
-    await fetchFiles()
+    // Update the in-memory file list
+    // TODO: When moving to a new directory, we need to filter out the moved file
+    files.value = files.value.map((f) => {
+      if (f.name === oldPath) {
+        return {
+          ...f,
+          name: newPath,
+          fullPath: f.fullPath.replace(oldPath, newPath),
+        }
+      }
+      return f
+    })
+    // Close the dialog
     moveDialogOpen.value = false
     moveDialogFile.value = null
   } catch (e) {

--- a/app/src/components/cirrus/CirrusFileExplorer.vue
+++ b/app/src/components/cirrus/CirrusFileExplorer.vue
@@ -597,7 +597,6 @@ const handleDelete = async (file: CirrusFileNode) => {
     border-color 0.15s,
     box-shadow 0.15s;
   background: $theme-palette-bg-inverse;
-  color: $theme-palette-text-primary;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.01);
 
   &:focus {

--- a/app/src/components/cirrus/CirrusFileExplorer.vue
+++ b/app/src/components/cirrus/CirrusFileExplorer.vue
@@ -214,6 +214,7 @@ const moveDialogOpen = ref(false)
 const moveDialogLoading = ref(false)
 const moveDialogError = ref('')
 const moveDialogNewPath = ref('')
+const moveDialogOldDeviceName = ref('')
 const moveDialogFile = ref<CirrusFileNode | null>(null)
 
 // Fetch files for the current path
@@ -338,7 +339,9 @@ const handleDownload = (file: CirrusFileNode) => {
   const relativePath = currentPath.value
     ? `${currentPath.value}/${fileName}`
     : fileName
-  const downloadUrl = `/api/v1/download/cirrus/${relativePath}`
+  const downloadUrl = `/api/v1/download/cirrus/${relativePath}${
+    file.deviceName ? `?device=${encodeURIComponent(file.deviceName)}` : ''
+  }`
 
   // Create a temporary link and click it to trigger download
   const link = document.createElement('a')
@@ -354,8 +357,8 @@ const handleRename = (file: CirrusFileNode) => {
   moveDialogError.value = ''
   // Default to just renaming the file/folder name, not the whole path
   moveDialogNewPath.value = file.name
-  console.log(file)
   moveDialogOpen.value = true
+  moveDialogOldDeviceName.value = file.deviceName
 }
 
 const submitMoveDialog = async () => {
@@ -370,7 +373,13 @@ const submitMoveDialog = async () => {
       moveDialogLoading.value = false
       return
     }
-    await CirrusService.moveFile(oldPath, newPath)
+    // TODO: Allow for supporting a new target device in the future
+    await CirrusService.moveFile(
+      oldPath,
+      newPath,
+      moveDialogOldDeviceName.value,
+      moveDialogOldDeviceName.value,
+    )
     // Update UI: refetch files and close dialog
     await fetchFiles()
     moveDialogOpen.value = false
@@ -404,7 +413,7 @@ const handleDelete = async (file: CirrusFileNode) => {
     params.append('rootDir', currentPath.value)
     params.append('filePaths', fileName)
 
-    await CirrusService.deleteFile(currentPath.value, fileName)
+    await CirrusService.deleteFile(currentPath.value, fileName, file.deviceName)
 
     // Remove the file from the in-memory list
     files.value = files.value.filter((f) => {

--- a/app/src/components/cirrus/CirrusFileExplorer.vue
+++ b/app/src/components/cirrus/CirrusFileExplorer.vue
@@ -194,7 +194,7 @@ const files = ref<CirrusFileNode[]>([])
 const loading = ref(false)
 const error = ref<string | null>(null)
 const view = ref<'list' | 'grid'>('list')
-const showDeviceBadges = ref(false)
+const showDeviceBadges = ref(true)
 
 // File viewer state
 const fileViewerOpen = ref(false)

--- a/app/src/services/cirrusService.ts
+++ b/app/src/services/cirrusService.ts
@@ -5,10 +5,17 @@ export default class CirrusService {
   /**
    * Move or rename a file or directory in Cirrus
    */
-  static moveFile = async (oldPath: string, newPath: string): Promise<void> => {
+  static moveFile = async (
+    oldPath: string,
+    newPath: string,
+    oldDeviceName?: string,
+    newDeviceName?: string,
+  ): Promise<void> => {
     await HttpService.put('/api/v1/cirrus', {
-      filePath: oldPath,
+      oldFilePath: oldPath,
       newFilePath: newPath,
+      oldDevice: oldDeviceName,
+      newDevice: newDeviceName,
     })
   }
 
@@ -113,10 +120,17 @@ export default class CirrusService {
   /**
    * Delete a file in Cirrus
    */
-  static async deleteFile(rootDir: string, fileName: string): Promise<void> {
+  static async deleteFile(
+    rootDir: string,
+    fileName: string,
+    deviceName?: string,
+  ): Promise<void> {
     const params = new URLSearchParams()
     params.append('rootDir', rootDir)
     params.append('filePaths', fileName)
+    if (deviceName) {
+      params.append('device', deviceName)
+    }
     const url = `/api/v1/cirrus?${params.toString()}`
     const response = await HttpService.delete(url)
     if (!response.ok) throw new Error('Failed to delete file')

--- a/internal/server/api/v1/cirrus/list_files.go
+++ b/internal/server/api/v1/cirrus/list_files.go
@@ -49,6 +49,19 @@ func getCirrusFilesForDevice(filePath string, deviceName string) ([]*cirrusutil.
 		}
 		allFiles = append(allFiles, files...)
 	}
+	// Remove any duplicate folders (can happen if multiple devices have same dir structure)
+	// TODO: This should be improved to actually list off ALL devices on the file node then, so the
+	// client can show which devices have that folder, and file operations on the file can happen on all devices
+	seenPaths := make(map[string]bool)
+	uniqueFiles := make([]*cirrusutil.DeviceFileInfo, 0, len(allFiles))
+	for _, file := range allFiles {
+		name := file.FileInfo.Name()
+		if !seenPaths[name] {
+			seenPaths[name] = true
+			uniqueFiles = append(uniqueFiles, file)
+		}
+	}
+	allFiles = uniqueFiles
 	return allFiles, nil
 }
 

--- a/internal/server/api/v1/cirrus/move_file.go
+++ b/internal/server/api/v1/cirrus/move_file.go
@@ -11,7 +11,7 @@ import (
 )
 
 type moveFileRequest struct {
-	FilePath    string `json:"filePath"`
+	OldFilePath string `json:"oldFilePath"`
 	NewFilePath string `json:"newFilePath"`
 	OldDevice   string `json:"oldDevice"`
 	NewDevice   string `json:"newDevice"`
@@ -30,7 +30,7 @@ var moveFileRoute = serverutil.ApiRoute(
 		}
 		channel := deps.Worker().GetMoveFileChannel()
 		channel <- cirrusutil.MoveFileParams{
-			FilePath:      req.FilePath,
+			OldFilePath:   req.OldFilePath,
 			NewFilePath:   req.NewFilePath,
 			OldDeviceName: req.OldDevice,
 			NewDeviceName: req.NewDevice,

--- a/pkg/util/cirrusutil/cirrusutil_test.go
+++ b/pkg/util/cirrusutil/cirrusutil_test.go
@@ -395,7 +395,7 @@ func TestDeleteFiles_SingleDevice(t *testing.T) {
 
 func TestMoveFile(t *testing.T) {
 	params := MoveFileParams{
-		FilePath:    "old/path/file.txt",
+		OldFilePath: "old/path/file.txt",
 		NewFilePath: "new/path/file.txt",
 	}
 
@@ -608,7 +608,7 @@ func TestMoveFile_CreateDirectory(t *testing.T) {
 	// We can't easily test this without interfering with GetCirrusDir(),
 	// but we can at least verify the function structure
 	params := MoveFileParams{
-		FilePath:    "nonexistent/old.txt",
+		OldFilePath: "nonexistent/old.txt",
 		NewFilePath: "new/path/file.txt",
 	}
 
@@ -624,7 +624,7 @@ func TestMoveFile_ToRootDirectory(t *testing.T) {
 	// When NewFilePath has no directory component, filepath.Dir returns "."
 
 	params := MoveFileParams{
-		FilePath:    "subdir/file.txt",
+		OldFilePath: "subdir/file.txt",
 		NewFilePath: "newfile.txt", // No directory component
 	}
 
@@ -666,7 +666,7 @@ func TestMoveFile_ToRootDirectory(t *testing.T) {
 	defer os.RemoveAll(testSourceDir)
 
 	params2 := MoveFileParams{
-		FilePath:    "test_move_root/subdir/file.txt",
+		OldFilePath: "test_move_root/subdir/file.txt",
 		NewFilePath: "test_move_root/moved.txt",
 	}
 
@@ -685,7 +685,7 @@ func TestMoveFile_ToRootDirectory(t *testing.T) {
 	os.WriteFile(testSourceFile2, []byte("content2"), 0644)
 
 	params3 := MoveFileParams{
-		FilePath:    "test_move_root/subdir/file2.txt",
+		OldFilePath: "test_move_root/subdir/file2.txt",
 		NewFilePath: "rootfile.txt", // No directory path, filepath.Dir will return "."
 	}
 

--- a/pkg/util/cirrusutil/operations.go
+++ b/pkg/util/cirrusutil/operations.go
@@ -49,7 +49,7 @@ func DeleteFiles(params DeleteFilesParams) (*DeleteFilesResult, error) {
 
 // MoveFileParams contains parameters for moving a file
 type MoveFileParams struct {
-	FilePath      string
+	OldFilePath   string
 	NewFilePath   string
 	OldDeviceName string
 	NewDeviceName string
@@ -85,7 +85,7 @@ func MoveFile(params MoveFileParams) (*MoveFileResult, error) {
 		newCirrusDir = newDevice.CirrusDir
 	}
 
-	oldFullPath := filepath.Join(oldCirrusDir, params.FilePath)
+	oldFullPath := filepath.Join(oldCirrusDir, params.OldFilePath)
 	newFullPath := filepath.Join(newCirrusDir, params.NewFilePath)
 
 	newFullDir := filepath.Dir(newFullPath)

--- a/pkg/util/workerutil/workerutil_test.go
+++ b/pkg/util/workerutil/workerutil_test.go
@@ -146,7 +146,7 @@ func TestWorkerIntegration_MoveFile(t *testing.T) {
 	startWorkerAndQuitOnDone(t, func(w Worker) {
 		moveCh := w.GetMoveFileChannel()
 		moveCh <- cirrusutil.MoveFileParams{
-			FilePath:    oldName,
+			OldFilePath: oldName,
 			NewFilePath: newName,
 		}
 	})


### PR DESCRIPTION
What this means:

- Download files from external device
- Delete files on external device
- Move files inside of the same device

What this does not support:

- Folders that show up in both devices will not be treated as "one device" when being downloaded, deleted, or renamed, but only one will be acted on
- Cannot move files between devices yet