### PR TITLE
fix(#578): add fallback refresh after folder creation for WebSocket miss resilience

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -401,8 +401,12 @@ class _FileBrowserPageState extends State<FileBrowserPage>
         return;
       }
 
-      // Let the WebSocket event or next poll reconcile with the real data
       _showMessage('Created folder $folderName');
+      // Belt-and-suspenders: refresh after a short delay in case the WebSocket
+      // event is missed (dropped connection, buffering, etc.).
+      Future.delayed(const Duration(seconds: 3), () {
+        if (mounted) _refreshFileState();
+      });
     } catch (_) {
       debugPrint('[file_browser_page.dart] Error in catch block');
       if (!mounted) {


### PR DESCRIPTION
Addresses review feedback on #788.

## Change

After a successful `createFolder` call, schedules a best-effort `_refreshFileState()` with a 3-second delay. This reconciles the optimistic placeholder with authoritative server data in case the WebSocket event from #787 is missed (dropped connection, buffer overflow, etc.).

The primary update path remains the WebSocket event — this is purely a safety net. No change to the delete or upload paths.