### PR TITLE
fix(#801-802): use named params for serials/serial — fix CI compile error

### DIFF
--- a/lib/controllers/file_browser_controller.dart
+++ b/lib/controllers/file_browser_controller.dart
@@ -27,7 +27,7 @@ class FileBrowserController {
     String currentPath, {
     List<String>? serials,
   }) {
-    return CirrusService.getFiles(currentPath, serials);
+    return CirrusService.getFiles(currentPath, serials: serials);
   }
 
   /// Picks one or more files for upload.

--- a/lib/services/file_browser_actions.dart
+++ b/lib/services/file_browser_actions.dart
@@ -11,7 +11,7 @@ Future<void> uploadMultipartFilesToCurrentPath({
   return CirrusService.uploadFilesFromFormData(
     toRootDir(currentPath),
     selectedFiles,
-    deviceSerial,
+    serial: deviceSerial,
   );
 }
 


### PR DESCRIPTION
Fixes the frontend CI failure in #807.

## Problem

`CirrusService.getFiles` and `uploadFilesFromFormData` both use **named** optional parameters (`serials:` and `serial:` respectively), but the call sites in `FileBrowserController` and `file_browser_actions.dart` were passing them **positionally**. This caused a dart2js compile error:

```
Error: Too many positional arguments: 1 allowed, but 2 found.
    return CirrusService.getFiles(currentPath, serials);
```

## Fix

- `file_browser_controller.dart`: `getFiles(currentPath, serials)` → `getFiles(currentPath, serials: serials)`
- `file_browser_actions.dart`: `uploadFilesFromFormData(..., deviceSerial)` → `uploadFilesFromFormData(..., serial: deviceSerial)`