### PR TITLE
chore: add issue templates for chore, security, performance, and question

### DIFF
--- a/.github/ISSUE_TEMPLATE/chore.yaml
+++ b/.github/ISSUE_TEMPLATE/chore.yaml
@@ -1,0 +1,59 @@
+name: Chore / Maintenance
+description: Dependency updates, refactors, CI changes, tooling, cleanup — work that doesn't change user-facing behavior.
+title: "chore: "
+labels: ["chore"]
+projects: ["autobutler-org/2"]
+type: Task
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For internal work that keeps the project healthy but doesn't add features or fix bugs.
+  - type: dropdown
+    id: chore-type
+    attributes:
+      label: Type of chore
+      multiple: false
+      options:
+        - Dependency update
+        - Refactor / cleanup
+        - CI / tooling
+        - Documentation
+        - Test coverage
+        - Performance
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: What part of the codebase does this touch?
+      multiple: true
+      options:
+        - Backend (Go)
+        - Frontend (Flutter)
+        - CI / workflows
+        - Docs
+        - Tooling / scripts
+        - Dependencies
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What needs doing?
+      description: Describe the work. Include links to dependency changelogs, related PRs, or the thing that triggered this if relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now?
+      description: Is this blocking something? Routine hygiene? Security concern? Optional but helpful.
+  - type: textarea
+    id: bot-guidance
+    attributes:
+      label: Bot guidance
+      description: Anything for Sable or ExoKomodo to know when picking this up — scope limits, related issues, things to avoid touching.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Report a Security Vulnerability (Private)
     url: https://github.com/autobutler-org/autobutler/security/advisories/new
     about: For exploitable vulnerabilities — file a private advisory, not a public issue.
-  - name: Community Discord
-    url: https://discord.com/invite/clawd
-    about: Questions, help, and general discussion.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: GitHub Security Bug Bounty
-    url: https://bounty.github.com/
-    about: Please report security vulnerabilities here.
+  - name: Report a Security Vulnerability (Private)
+    url: https://github.com/autobutler-org/autobutler/security/advisories/new
+    about: For exploitable vulnerabilities — file a private advisory, not a public issue.
+  - name: Community Discord
+    url: https://discord.com/invite/clawd
+    about: Questions, help, and general discussion.

--- a/.github/ISSUE_TEMPLATE/performance.yaml
+++ b/.github/ISSUE_TEMPLATE/performance.yaml
@@ -1,0 +1,62 @@
+name: Performance Issue
+description: Something is slow, uses too much memory, or has unacceptable resource usage.
+title: "perf: "
+labels: ["performance"]
+projects: ["autobutler-org/2"]
+type: Bug
+assignees: []
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      multiple: true
+      options:
+        - Cirrus (Drive)
+        - Photos
+        - Docs
+        - Books
+        - General UI
+        - Backend
+        - N/A
+      default: 0
+    validations:
+      required: true
+  - type: dropdown
+    id: perf-type
+    attributes:
+      label: Type of issue
+      multiple: true
+      options:
+        - Slow load / response time
+        - High memory usage
+        - High CPU usage
+        - Large network payload
+        - Laggy UI / dropped frames
+        - Slow file transfer
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What's slow or heavy?
+      description: Describe what you're doing when you notice the problem and what the impact is.
+    validations:
+      required: true
+  - type: textarea
+    id: measurements
+    attributes:
+      label: Measurements
+      description: Numbers if you have them — response times, memory readings, transfer rates, browser DevTools data, etc.
+  - type: input
+    id: version
+    attributes:
+      label: AutoButler version
+      placeholder: "e.g. 0.17.0"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Hardware running AutoButler, number of files/devices, network setup — context that might affect the numbers.

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,0 +1,40 @@
+name: Question / Discussion
+description: Not sure if something is a bug or a feature? Want to discuss an approach before building it? Ask here.
+title: "question: "
+labels: ["question"]
+projects: ["autobutler-org/2"]
+type: Task
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For open-ended questions, design discussions, or "is this intentional?" checks. If you already know what you want to build, use the Feature or Epic template instead.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind of question
+      options:
+        - Design / architecture decision
+        - "Is this a bug or intentional?"
+        - How do I do X?
+        - Should we do X at all?
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: What's the question?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What led you here? What have you already tried or considered?
+  - type: textarea
+    id: options
+    attributes:
+      label: Options you're weighing
+      description: If this is a design decision, list the approaches and their tradeoffs.

--- a/.github/ISSUE_TEMPLATE/security.yaml
+++ b/.github/ISSUE_TEMPLATE/security.yaml
@@ -9,7 +9,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ⚠️ **Is this a vulnerability?** If it could be exploited to compromise user data or the device, please [file a private security advisory](https://github.com/autobutler-org/autobutler/security/advisories/new) instead of a public issue.
+        ⚠️ **Is this a vulnerability?** If it could be exploited to compromise user data or the device, please [file a private security advisory](https://github.com/autobutler-org/autobutler/security/advisories/new) instead of a public issue. Do not post details publicly.
 
         This template is for security *hardening*, *improvements*, or *non-exploitable* concerns.
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/security.yaml
+++ b/.github/ISSUE_TEMPLATE/security.yaml
@@ -1,0 +1,56 @@
+name: Security Issue
+description: Non-critical security concerns suitable for the public tracker. For vulnerabilities, use the private security advisory instead.
+title: "security: "
+labels: ["security"]
+projects: ["autobutler-org/2"]
+type: Bug
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ⚠️ **Is this a vulnerability?** If it could be exploited to compromise user data or the device, please [file a private security advisory](https://github.com/autobutler-org/autobutler/security/advisories/new) instead of a public issue.
+
+        This template is for security *hardening*, *improvements*, or *non-exploitable* concerns.
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - Low (hardening / defense-in-depth)
+        - Medium (exploitable under specific conditions)
+        - High (use private advisory instead)
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Authentication / authorization
+        - API / network
+        - File access / storage
+        - Dependencies
+        - CI / supply chain
+        - Configuration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the concern? What could go wrong, and under what conditions?
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-fix
+    attributes:
+      label: Suggested fix or mitigation
+      description: If you have a fix in mind, describe it here.
+  - type: input
+    id: version
+    attributes:
+      label: AutoButler version
+      placeholder: "e.g. 0.17.0"


### PR DESCRIPTION
Adds 4 new issue template types to complement the existing bug/feature/epic set.

## New templates

**Chore / Maintenance** — dependency updates, refactors, CI changes, cleanup. Includes a surface dropdown and a bot guidance field so Sable/ExoKomodo know scope when picking it up.

**Security Issue** — for non-exploitable hardening concerns. Includes a severity dropdown with a hard prompt to use private advisories for actual vulnerabilities. Updated `config.yml` to replace the generic GitHub bug bounty link with the autobutler-specific private advisory URL.

**Performance Issue** — slow responses, high memory, laggy UI. Structured fields for measurements and environment so there's something concrete to optimize against.

**Question / Discussion** — design decisions, architecture discussions, "is this a bug or intentional?" checks. Keeps these out of the bug tracker while still giving them a home.

Also updated `config.yml` contact links: replaced the generic GitHub security bounty URL with the actual private advisory link for this repo, and added the community Discord.