### PR TITLE
fix(#801): all chips selected shows no files — use set equality, filter blank serials

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -109,13 +109,22 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   }
 
   /// Converts the selected devicePaths into the serial values the backend expects.
+  /// Returns an empty list when all devices are selected (backend interprets
+  /// empty serials as "no filter — show all").
   List<String> _serialsForActiveDevices() {
-    if (_activeDevicePaths.length == _allDevices.length) {
-      return const []; // empty = all devices, no filter
+    final allPaths = _allDevices.map((d) => d.devicePath).toSet();
+    // If every known device is selected, pass no filter rather than an explicit
+    // serial list. This avoids the edge case where count matches but content
+    // differs (e.g. a device was added/removed between loads), and also avoids
+    // sending serial='' for the internal device which confuses the backend.
+    if (_activeDevicePaths.containsAll(allPaths) &&
+        allPaths.containsAll(_activeDevicePaths)) {
+      return const [];
     }
     return _allDevices
         .where((d) => _activeDevicePaths.contains(d.devicePath))
-        .map((d) => d.serial) // '' for internal devices — backend expects this
+        .map((d) => d.serial)
+        .where((s) => s.isNotEmpty) // never send blank serial as a filter
         .toList();
   }
 


### PR DESCRIPTION
Fixes a bug found during local review of #814.

## Problem

When all device filter chips are selected, the file browser shows nothing instead of all files.

**Root cause — two related issues:**

**1. Count comparison instead of set equality**
`_serialsForActiveDevices` used `_activeDevicePaths.length == _allDevices.length` to detect the all-selected state. If a device is added or removed between loads, the counts can match while the contents differ, causing the fallthrough to the serial filter path with stale data.

**2. Blank serial sent as a filter value**
The internal device has `serial = ''`. When the all-selected check fails, `serial=''` gets included in the query params. The backend treats `serial=` as an explicit filter for a device with no serial, returning nothing instead of falling back to all files.

## Fix

- Replace length comparison with proper set equality (`containsAll` both ways)
- Filter out blank serials before building the query: `.where((s) => s.isNotEmpty)`

## PR Type

- [x] Bug fix

## Surface

- [x] Frontend (Flutter)

## Testing

- [x] Local testing recommended — load Cirrus with multiple devices, verify all chips selected shows all files, partial selection filters correctly