### PR TITLE
fix(#837): fix SPA fallback — serve index.html not index.htm on NoRoute

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -63,7 +63,7 @@ func setupStaticRoutes(engine *gin.Engine) error {
 
 			// So this will otherwise automatically redirect -
 			//   https://github.com/golang/go/blob/a7e16abb22f1b249d2691b32a5d20206282898f2/src/net/http/fs.go#L593
-			c.FileFromFS("public/index.htm", http.FS(public))
+			c.FileFromFS("public/index.html", http.FS(public))
 		},
 	)
 	return nil


### PR DESCRIPTION
Closes #837

## What

Refreshing any client-side route (e.g. `/cirrus`, `/photos`, `/settings`) returned a 404. The `NoRoute` handler in `routes.go` was pointing at `public/index.htm` but Flutter's web build outputs `public/index.html` — one missing `l`.

## Change

```go
// before
c.FileFromFS("public/index.htm", http.FS(public))

// after  
c.FileFromFS("public/index.html", http.FS(public))
```

## Why this matters

Without this, the app is effectively broken for web users who:
- Bookmark a deep link
- Refresh the page on any route other than `/`
- Share a link to a specific page

## PR Type

- [x] Bug fix

## Surface

- [x] Backend (Go)

## Testing

- [x] Local testing recommended — navigate to `http://autobutler.local:8080/cirrus`, hit refresh, confirm 200 not 404
- [x] `go build ./...` and `go vet ./...` clean