### PR TITLE
chore: add Flutter Linux artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ app.*.map.json
 # Setup artifacts
 flutter.zip
 
+# Flutter Linux artifacts
+/linux/
+
 # Ralph loops
 .ralph/
 


### PR DESCRIPTION
## What

The Openclaw bots are often building for the linux platform on accident, and generating build artifacts we do not want to commit.

## Changes

- Adds `/linux/` to `.gitignore`

## PR Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / content
- [x] Chore / tooling
- [ ] Tests

## Surface

- [ ] Backend (Go)
- [x] Frontend (Flutter)
- [ ] API / swagger
- [ ] CI / workflows
- [ ] Docs / content only

## Testing

- [ ] Local testing recommended (UI changes, routing, behavior changes)
- [ ] Local testing not needed (logic-only, docs, trivial change)
- [ ] Includes new automated tests
- [x] Manually tested by author

## Bot Review Guidance

<!-- Optional: direct Sable / ExoKomodo attention to the gnarly part,
     e.g. "focus on concurrency in pkg/util/eventbus" or "verify no broken image refs" -->

## Notes

<!-- Optional. Tradeoffs, follow-ups, things reviewers should know. -->
