### PR TITLE
feat: Phase 1 remote access via Tailscale tsnet (#498)

### DIFF
--- a/internal/server/api/v1/settings/remote_access.go
+++ b/internal/server/api/v1/settings/remote_access.go
@@ -1,20 +1,17 @@
 package v1_settings
 
 import (
-	"fmt"
-	"net/http"
-	"sync"
+	"errors"
 
-	"github.com/autobutler-org/autobutler/pkg/util/provisionutil"
 	"github.com/autobutler-org/autobutler/pkg/util/remoteutil"
 	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
 	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
 	"github.com/gin-gonic/gin"
 )
 
-// enableMu guards against concurrent calls to enableRemoteAccess, which would
-// mint multiple Headscale keys. Only one enable is allowed at a time.
-var enableMu sync.Mutex
+type RemoteAccessRequest struct {
+	AuthKey string `json:"authKey"`
+}
 
 type RemoteAccessResponse struct {
 	Enabled   bool   `json:"enabled"`
@@ -39,49 +36,38 @@ var getRemoteAccessRoute = serverutil.ApiRoute(
 
 // enableRemoteAccess godoc
 // @Summary Enable remote access via Tailscale
-// @Description Auto-provisions a Headscale pre-auth key and starts a tsnet node proxying traffic to the local server
+// @Description Starts a Tailscale tsnet node with the provided auth key and proxies traffic to the local server
 // @Tags settings
 // @Accept json
 // @Produce json
+// @Param body body RemoteAccessRequest true "Tailscale auth key"
 // @Success 200 {object} RemoteAccessResponse
-// @Failure 409 {object} serverutil.Response "Already enabling"
+// @Failure 400 {object} serverutil.Response "Bad Request"
 // @Failure 500 {object} serverutil.Response "Internal Server Error"
 // @Router /settings/remote-access [post]
 var enableRemoteAccessRoute = serverutil.ApiRoute(
 	"POST", "/settings/remote-access", func(c *gin.Context) *serverutil.Response {
-		// Guard against concurrent enable calls minting multiple auth keys.
-		if !enableMu.TryLock() {
-			return serverutil.NewResponse().
-				WithStatusCode(http.StatusConflict).
-				WithError(fmt.Errorf("remote access enable already in progress"))
-		}
-		defer enableMu.Unlock()
-
 		if remoteutil.IsRunning() {
 			return serverutil.Ok().WithData(RemoteAccessResponse{
 				Enabled:   true,
 				RemoteURL: remoteutil.RemoteURL(),
 			})
 		}
-
-		deviceID, err := provisionutil.GetDeviceID()
-		if err != nil {
-			return serverutil.InternalServerError(fmt.Errorf("device id: %w", err))
+		var req RemoteAccessRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			return serverutil.BadRequest(err)
 		}
-
-		authKey, err := provisionutil.ProvisionAuthKey(deviceID)
-		if err != nil {
-			return serverutil.InternalServerError(fmt.Errorf("provision: %w", err))
+		if req.AuthKey == "" {
+			return serverutil.BadRequest(errors.New("authKey is required"))
 		}
-
-		if err := remoteutil.Start(authKey); err != nil {
+		if err := remoteutil.Start(req.AuthKey); err != nil {
 			return serverutil.InternalServerError(err)
 		}
 		if err := remoteutil.StartProxy(serverutil.ServerPort()); err != nil {
 			remoteutil.Stop()
 			return serverutil.InternalServerError(err)
 		}
-		if err := settingsutil.SetRemoteAccess(true); err != nil {
+		if err := settingsutil.SetRemoteAccess(true, req.AuthKey); err != nil {
 			return serverutil.InternalServerError(err)
 		}
 		return serverutil.Ok().WithData(RemoteAccessResponse{
@@ -102,7 +88,7 @@ var enableRemoteAccessRoute = serverutil.ApiRoute(
 var disableRemoteAccessRoute = serverutil.ApiRoute(
 	"DELETE", "/settings/remote-access", func(c *gin.Context) *serverutil.Response {
 		remoteutil.Stop()
-		if err := settingsutil.SetRemoteAccess(false); err != nil {
+		if err := settingsutil.SetRemoteAccess(false, ""); err != nil {
 			return serverutil.InternalServerError(err)
 		}
 		return serverutil.Ok().WithData(RemoteAccessResponse{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,16 +101,24 @@ func StartServer(deps deputil.Dependencies) error {
 		port = "8080"
 	}
 
-	if enabled, authKey := settingsutil.GetRemoteAccess(); enabled && authKey != "" {
-		if err := remoteutil.Start(authKey); err != nil {
-			log.Printf("[remote] failed to start: %v", err)
+	if settingsutil.GetRemoteAccess() {
+		deviceID, idErr := provisionutil.GetDeviceID()
+		if idErr != nil {
+			log.Printf("[remote] failed to get device id: %v", idErr)
 		} else {
-			portNum, convErr := strconv.Atoi(port)
-			if convErr != nil {
-				portNum = 8080
-			}
-			if err := remoteutil.StartProxy(portNum); err != nil {
-				log.Printf("[remote] failed to start proxy: %v", err)
+			authKey, keyErr := provisionutil.ProvisionAuthKey(deviceID)
+			if keyErr != nil {
+				log.Printf("[remote] failed to provision auth key: %v", keyErr)
+			} else if err := remoteutil.Start(authKey); err != nil {
+				log.Printf("[remote] failed to start: %v", err)
+			} else {
+				portNum, convErr := strconv.Atoi(port)
+				if convErr != nil {
+					portNum = 8080
+				}
+				if err := remoteutil.StartProxy(portNum); err != nil {
+					log.Printf("[remote] failed to start proxy: %v", err)
+				}
 			}
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,17 +5,13 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 
 	docs "github.com/autobutler-org/autobutler/docs/swagger"
 	"github.com/autobutler-org/autobutler/internal/server/middleware"
 	"github.com/autobutler-org/autobutler/pkg/botel"
 	"github.com/autobutler-org/autobutler/pkg/util/deputil"
-	"github.com/autobutler-org/autobutler/pkg/util/provisionutil"
 	"github.com/autobutler-org/autobutler/pkg/util/remoteutil"
-	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
 	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
 	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
 	"github.com/autobutler-org/autobutler/pkg/util/workerutil"
@@ -69,56 +65,22 @@ func StartServer(deps deputil.Dependencies) error {
 	if err := setupServices(deps); err != nil {
 		return fmt.Errorf("failed to setup services: %w", err)
 	}
-	go startAutoUpdateChecker(context.Background())
-
-	portNum := serverutil.ServerPort()
-	port := strconv.Itoa(portNum)
-
-	if settingsutil.GetRemoteAccess() {
-		if err := startRemoteAccess(portNum); err != nil {
-			log.Printf("[remote] failed to start: %v", err)
-		}
-	}
-
-	// Graceful shutdown: stop tsnet and telemetry on SIGINT/SIGTERM.
-	go func() {
-		quit := make(chan os.Signal, 1)
-		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-		<-quit
-		log.Println("[server] shutting down...")
-		remoteutil.Stop()
-		if err := tp.Shutdown(context.Background()); err != nil {
-			log.Printf("Error shutting down tracer provider: %v", err)
-		}
-		if err := mp.Shutdown(context.Background()); err != nil {
-			log.Printf("Error shutting down meter provider: %v", err)
-		}
-		os.Exit(0)
-	}()
 
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 
-	if settingsutil.GetRemoteAccess() {
-		deviceID, idErr := provisionutil.GetDeviceID()
-		if idErr != nil {
-			log.Printf("[remote] failed to get device id: %v", idErr)
+	if enabled, authKey := settingsutil.GetRemoteAccess(); enabled && authKey != "" {
+		if err := remoteutil.Start(authKey); err != nil {
+			log.Printf("[remote] failed to start: %v", err)
 		} else {
-			authKey, keyErr := provisionutil.ProvisionAuthKey(deviceID)
-			if keyErr != nil {
-				log.Printf("[remote] failed to provision auth key: %v", keyErr)
-			} else if err := remoteutil.Start(authKey); err != nil {
-				log.Printf("[remote] failed to start: %v", err)
-			} else {
-				portNum, convErr := strconv.Atoi(port)
-				if convErr != nil {
-					portNum = 8080
-				}
-				if err := remoteutil.StartProxy(portNum); err != nil {
-					log.Printf("[remote] failed to start proxy: %v", err)
-				}
+			portNum, convErr := strconv.Atoi(port)
+			if convErr != nil {
+				portNum = 8080
+			}
+			if err := remoteutil.StartProxy(portNum); err != nil {
+				log.Printf("[remote] failed to start proxy: %v", err)
 			}
 		}
 	}
@@ -139,16 +101,4 @@ func StartServer(deps deputil.Dependencies) error {
 	}
 
 	return nil
-}
-
-func startRemoteAccess(localPort int) error {
-	return remoteutil.EnsureStarted(localPort, provisionForRemoteAccess)
-}
-
-func provisionForRemoteAccess() (string, error) {
-	deviceID, err := provisionutil.GetDeviceID()
-	if err != nil {
-		return "", fmt.Errorf("device id: %w", err)
-	}
-	return provisionutil.ProvisionAuthKey(deviceID)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -96,6 +96,25 @@ func StartServer(deps deputil.Dependencies) error {
 		os.Exit(0)
 	}()
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	if enabled, authKey := settingsutil.GetRemoteAccess(); enabled && authKey != "" {
+		if err := remoteutil.Start(authKey); err != nil {
+			log.Printf("[remote] failed to start: %v", err)
+		} else {
+			portNum, convErr := strconv.Atoi(port)
+			if convErr != nil {
+				portNum = 8080
+			}
+			if err := remoteutil.StartProxy(portNum); err != nil {
+				log.Printf("[remote] failed to start proxy: %v", err)
+			}
+		}
+	}
+
 	router := gin.Default()
 	// Disable automatic redirects so unmatched routes (e.g. /health, /photos)
 	// fall through to the NoRoute SPA handler instead of 301-redirecting to /.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strconv"
+	"os/signal"
+	"syscall"
 
 	docs "github.com/autobutler-org/autobutler/docs/swagger"
 	"github.com/autobutler-org/autobutler/internal/server/middleware"
 	"github.com/autobutler-org/autobutler/pkg/botel"
 	"github.com/autobutler-org/autobutler/pkg/util/deputil"
 	"github.com/autobutler-org/autobutler/pkg/util/remoteutil"
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
 	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
 	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
 	"github.com/autobutler-org/autobutler/pkg/util/workerutil"
@@ -66,24 +68,32 @@ func StartServer(deps deputil.Dependencies) error {
 		return fmt.Errorf("failed to setup services: %w", err)
 	}
 
-	port := os.Getenv("PORT")
-	if port == "" {
-		port = "8080"
-	}
+	portNum := serverutil.ServerPort()
+	port := fmt.Sprintf("%d", portNum)
 
 	if enabled, authKey := settingsutil.GetRemoteAccess(); enabled && authKey != "" {
 		if err := remoteutil.Start(authKey); err != nil {
 			log.Printf("[remote] failed to start: %v", err)
-		} else {
-			portNum, convErr := strconv.Atoi(port)
-			if convErr != nil {
-				portNum = 8080
-			}
-			if err := remoteutil.StartProxy(portNum); err != nil {
-				log.Printf("[remote] failed to start proxy: %v", err)
-			}
+		} else if err := remoteutil.StartProxy(portNum); err != nil {
+			log.Printf("[remote] failed to start proxy: %v", err)
 		}
 	}
+
+	// Graceful shutdown: stop tsnet and telemetry on SIGINT/SIGTERM.
+	go func() {
+		quit := make(chan os.Signal, 1)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+		<-quit
+		log.Println("[server] shutting down...")
+		remoteutil.Stop()
+		if err := tp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down tracer provider: %v", err)
+		}
+		if err := mp.Shutdown(context.Background()); err != nil {
+			log.Printf("Error shutting down meter provider: %v", err)
+		}
+		os.Exit(0)
+	}()
 
 	router := gin.Default()
 	// Disable automatic redirects so unmatched routes (e.g. /health, /photos)

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,18 +1,18 @@
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/app_settings.dart';
-import 'package:autobutler/services/smb_service.dart';
 import 'package:autobutler/services/auth_service.dart';
-import 'package:autobutler/services/health_service.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/services/connected_devices_service.dart';
+import 'package:autobutler/services/health_service.dart';
 import 'package:autobutler/services/remote_access_service.dart';
 import 'package:autobutler/services/sbom_service.dart';
 import 'package:autobutler/services/settings_service.dart';
+import 'package:autobutler/services/smb_service.dart';
 import 'package:autobutler/services/storage_service.dart';
 import 'package:autobutler/utils/autobutler_widget.dart';
+import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/core/copy_button.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
-import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/refresh_icon_button.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -791,7 +791,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            'Failed to load remote access status',
+                            'Failed to load remote access status: $_remoteAccessError',
                             style: TextStyle(
                               color: Theme.of(context).colorScheme.error,
                             ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -114,18 +114,31 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
+<<<<<<< HEAD
   Future<void> _enableRemoteAccess() async {
     setState(() => _isTogglingRemoteAccess = true);
     try {
       final status = await RemoteAccessService.enable();
+=======
+  Future<void> _enableRemoteAccess(String authKey) async {
+    setState(() => _isTogglingRemoteAccess = true);
+    try {
+      final status = await RemoteAccessService.enable(authKey);
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
       if (!mounted) return;
       setState(() {
         _remoteAccessStatus = status;
         _isTogglingRemoteAccess = false;
       });
+<<<<<<< HEAD
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Remote access enabled')));
+=======
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Remote access enabled')),
+      );
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     } catch (e) {
       if (!mounted) return;
       setState(() => _isTogglingRemoteAccess = false);
@@ -165,9 +178,15 @@ class _SettingsPageState extends State<SettingsPage> {
         _remoteAccessStatus = status;
         _isTogglingRemoteAccess = false;
       });
+<<<<<<< HEAD
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Remote access disabled')));
+=======
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Remote access disabled')),
+      );
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     } catch (e) {
       if (!mounted) return;
       setState(() => _isTogglingRemoteAccess = false);
@@ -175,6 +194,65 @@ class _SettingsPageState extends State<SettingsPage> {
         SnackBar(content: Text('Failed to disable remote access: $e')),
       );
     }
+<<<<<<< HEAD
+=======
+  }
+
+  Future<void> _showEnableRemoteAccessDialog() async {
+    final controller = TextEditingController();
+    final result = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Enable remote access'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Enter a Tailscale auth key to connect this butler to your tailnet.',
+            ),
+            const SizedBox(height: 6),
+            const Text(
+              'Get one from tailscale.com/admin/settings/keys',
+              style: TextStyle(fontSize: 12, color: Colors.grey),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: controller,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'Auth key',
+                hintText: 'tskey-auth-...',
+                border: OutlineInputBorder(),
+              ),
+              autofocus: true,
+              onSubmitted: (v) {
+                if (v.trim().isNotEmpty) Navigator.of(ctx).pop(v.trim());
+              },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              final key = controller.text.trim();
+              if (key.isNotEmpty) Navigator.of(ctx).pop(key);
+            },
+            child: const Text('Enable'),
+          ),
+        ],
+      ),
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      controller.dispose();
+    });
+    if (result != null && result.isNotEmpty) {
+      await _enableRemoteAccess(result);
+    }
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
   }
 
   Future<void> _loadDevices() async {
@@ -787,6 +865,7 @@ class _SettingsPageState extends State<SettingsPage> {
                         ),
                       )
                     : _remoteAccessError != null
+<<<<<<< HEAD
                     ? Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -874,6 +953,107 @@ class _SettingsPageState extends State<SettingsPage> {
                           ),
                         ],
                       ),
+=======
+                        ? Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Failed to load remote access status',
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                              ),
+                              const SizedBox(height: 8),
+                              OutlinedButton.icon(
+                                onPressed: _loadRemoteAccess,
+                                icon: const Icon(Icons.refresh, size: 16),
+                                label: const Text('Retry'),
+                              ),
+                            ],
+                          )
+                        : _remoteAccessStatus?.enabled == true
+                            ? Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    children: [
+                                      const Icon(
+                                        Icons.cloud_done_outlined,
+                                        size: 16,
+                                        color: Colors.green,
+                                      ),
+                                      const SizedBox(width: 6),
+                                      const Text(
+                                        'Connected via Tailscale',
+                                        style: TextStyle(
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  if (_remoteAccessStatus?.remoteUrl != null &&
+                                      _remoteAccessStatus!
+                                          .remoteUrl!.isNotEmpty) ...[
+                                    const SizedBox(height: 8),
+                                    _CodeBlock(
+                                      text: _remoteAccessStatus!.remoteUrl!,
+                                    ),
+                                  ],
+                                  const SizedBox(height: 12),
+                                  OutlinedButton.icon(
+                                    onPressed: _isTogglingRemoteAccess
+                                        ? null
+                                        : _disableRemoteAccess,
+                                    icon: _isTogglingRemoteAccess
+                                        ? const SizedBox(
+                                            width: 14,
+                                            height: 14,
+                                            child:
+                                                CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          )
+                                        : const Icon(
+                                            Icons.link_off,
+                                            size: 16,
+                                          ),
+                                    label: const Text('Disable'),
+                                    style: OutlinedButton.styleFrom(
+                                      foregroundColor:
+                                          Theme.of(context).colorScheme.error,
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Text(
+                                    'Access your butler from anywhere using Tailscale.',
+                                  ),
+                                  const SizedBox(height: 12),
+                                  OutlinedButton.icon(
+                                    onPressed: _isTogglingRemoteAccess
+                                        ? null
+                                        : _showEnableRemoteAccessDialog,
+                                    icon: _isTogglingRemoteAccess
+                                        ? const SizedBox(
+                                            width: 14,
+                                            height: 14,
+                                            child:
+                                                CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          )
+                                        : const Icon(
+                                            Icons.vpn_key_outlined,
+                                            size: 16,
+                                          ),
+                                    label: const Text('Enable remote access'),
+                                  ),
+                                ],
+                              ),
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
               ),
             ),
           ],

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -7,7 +7,6 @@ import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/services/connected_devices_service.dart';
 import 'package:autobutler/services/remote_access_service.dart';
 import 'package:autobutler/services/sbom_service.dart';
-import 'package:autobutler/services/settings_service.dart';
 import 'package:autobutler/services/storage_service.dart';
 import 'package:autobutler/utils/autobutler_widget.dart';
 import 'package:autobutler/widgets/core/copy_button.dart';
@@ -36,10 +35,6 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _isLoadingVersionInfo = false;
   bool _isUpdatingVersion = false;
   String? _versionLoadError;
-
-  bool _autoUpdate = false;
-  bool _autoUpdateLoadFailed = false;
-  bool _isLoadingAutoUpdate = false;
 
   // SBOM state
   GoSbom? _goSbom;
@@ -77,7 +72,6 @@ class _SettingsPageState extends State<SettingsPage> {
     _refreshIntervalSeconds = AppSettings.instance.refreshIntervalSeconds;
     setState(() {});
     _loadVersionInfo();
-    _loadSettings();
     _loadSbom();
     _loadDevices();
     _loadStorageDevices();
@@ -114,31 +108,18 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
-<<<<<<< HEAD
-  Future<void> _enableRemoteAccess() async {
-    setState(() => _isTogglingRemoteAccess = true);
-    try {
-      final status = await RemoteAccessService.enable();
-=======
   Future<void> _enableRemoteAccess(String authKey) async {
     setState(() => _isTogglingRemoteAccess = true);
     try {
       final status = await RemoteAccessService.enable(authKey);
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
       if (!mounted) return;
       setState(() {
         _remoteAccessStatus = status;
         _isTogglingRemoteAccess = false;
       });
-<<<<<<< HEAD
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Remote access enabled')));
-=======
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Remote access enabled')),
-      );
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     } catch (e) {
       if (!mounted) return;
       setState(() => _isTogglingRemoteAccess = false);
@@ -178,15 +159,9 @@ class _SettingsPageState extends State<SettingsPage> {
         _remoteAccessStatus = status;
         _isTogglingRemoteAccess = false;
       });
-<<<<<<< HEAD
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text('Remote access disabled')));
-=======
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Remote access disabled')),
-      );
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     } catch (e) {
       if (!mounted) return;
       setState(() => _isTogglingRemoteAccess = false);
@@ -194,8 +169,6 @@ class _SettingsPageState extends State<SettingsPage> {
         SnackBar(content: Text('Failed to disable remote access: $e')),
       );
     }
-<<<<<<< HEAD
-=======
   }
 
   Future<void> _showEnableRemoteAccessDialog() async {
@@ -252,7 +225,6 @@ class _SettingsPageState extends State<SettingsPage> {
     if (result != null && result.isNotEmpty) {
       await _enableRemoteAccess(result);
     }
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
   }
 
   Future<void> _loadDevices() async {
@@ -418,29 +390,6 @@ class _SettingsPageState extends State<SettingsPage> {
       _sbomError = errors.isEmpty ? null : errors.join('\n');
       _isLoadingSbom = false;
     });
-  }
-
-  Future<void> _loadSettings() async {
-    if (AppSettings.instance.activeHost == null) return;
-    setState(() {
-      _isLoadingAutoUpdate = true;
-    });
-    try {
-      final autoUpdate = await SettingsService.getAutoUpdate();
-      if (!mounted) return;
-      setState(() {
-        _autoUpdate = autoUpdate;
-        _autoUpdateLoadFailed = false;
-        _isLoadingAutoUpdate = false;
-      });
-    } catch (e) {
-      debugPrint('[settings_page.dart] Error loading settings: $e');
-      if (!mounted) return;
-      setState(() {
-        _autoUpdateLoadFailed = true;
-        _isLoadingAutoUpdate = false;
-      });
-    }
   }
 
   Future<void> _loadVersionInfo() async {
@@ -767,58 +716,6 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ),
           ),
-          const SizedBox(height: 16),
-          if (AppSettings.instance.activeHost != null)
-            Card(
-              child: _isLoadingAutoUpdate
-                  ? const ListTile(
-                      title: Text('Automatic updates'),
-                      subtitle: Text(
-                        'AutoButler will check for and install updates daily',
-                      ),
-                      trailing: SizedBox(
-                        width: 24,
-                        height: 24,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    )
-                  : SwitchListTile(
-                      title: const Text('Automatic updates'),
-                      subtitle: _autoUpdateLoadFailed
-                          ? const Text(
-                              'Could not load setting — server may be unreachable',
-                              style: TextStyle(color: Colors.red),
-                            )
-                          : const Text(
-                              'AutoButler will check for and install updates daily',
-                            ),
-                      value: _autoUpdate,
-                      onChanged: _autoUpdateLoadFailed
-                          ? null
-                          : (newValue) async {
-                              setState(() {
-                                _autoUpdate = newValue;
-                              });
-                              final messenger = ScaffoldMessenger.of(context);
-                              try {
-                                await SettingsService.setAutoUpdate(newValue);
-                              } catch (e) {
-                                debugPrint(
-                                  '[settings_page.dart] Error saving auto-update: $e',
-                                );
-                                if (!mounted) return;
-                                setState(() {
-                                  _autoUpdate = !newValue;
-                                });
-                                messenger.showSnackBar(
-                                  SnackBar(
-                                    content: Text('Failed to save setting: $e'),
-                                  ),
-                                );
-                              }
-                            },
-                    ),
-            ),
           const SizedBox(height: 24),
           const Text(
             'Auto-refresh interval',
@@ -865,7 +762,6 @@ class _SettingsPageState extends State<SettingsPage> {
                         ),
                       )
                     : _remoteAccessError != null
-<<<<<<< HEAD
                     ? Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -939,7 +835,7 @@ class _SettingsPageState extends State<SettingsPage> {
                           OutlinedButton.icon(
                             onPressed: _isTogglingRemoteAccess
                                 ? null
-                                : _enableRemoteAccess,
+                                : _showEnableRemoteAccessDialog,
                             icon: _isTogglingRemoteAccess
                                 ? const SizedBox(
                                     width: 14,
@@ -953,107 +849,6 @@ class _SettingsPageState extends State<SettingsPage> {
                           ),
                         ],
                       ),
-=======
-                        ? Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Failed to load remote access status',
-                                style: TextStyle(
-                                  color: Theme.of(context).colorScheme.error,
-                                ),
-                              ),
-                              const SizedBox(height: 8),
-                              OutlinedButton.icon(
-                                onPressed: _loadRemoteAccess,
-                                icon: const Icon(Icons.refresh, size: 16),
-                                label: const Text('Retry'),
-                              ),
-                            ],
-                          )
-                        : _remoteAccessStatus?.enabled == true
-                            ? Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    children: [
-                                      const Icon(
-                                        Icons.cloud_done_outlined,
-                                        size: 16,
-                                        color: Colors.green,
-                                      ),
-                                      const SizedBox(width: 6),
-                                      const Text(
-                                        'Connected via Tailscale',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  if (_remoteAccessStatus?.remoteUrl != null &&
-                                      _remoteAccessStatus!
-                                          .remoteUrl!.isNotEmpty) ...[
-                                    const SizedBox(height: 8),
-                                    _CodeBlock(
-                                      text: _remoteAccessStatus!.remoteUrl!,
-                                    ),
-                                  ],
-                                  const SizedBox(height: 12),
-                                  OutlinedButton.icon(
-                                    onPressed: _isTogglingRemoteAccess
-                                        ? null
-                                        : _disableRemoteAccess,
-                                    icon: _isTogglingRemoteAccess
-                                        ? const SizedBox(
-                                            width: 14,
-                                            height: 14,
-                                            child:
-                                                CircularProgressIndicator(
-                                              strokeWidth: 2,
-                                            ),
-                                          )
-                                        : const Icon(
-                                            Icons.link_off,
-                                            size: 16,
-                                          ),
-                                    label: const Text('Disable'),
-                                    style: OutlinedButton.styleFrom(
-                                      foregroundColor:
-                                          Theme.of(context).colorScheme.error,
-                                    ),
-                                  ),
-                                ],
-                              )
-                            : Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  const Text(
-                                    'Access your butler from anywhere using Tailscale.',
-                                  ),
-                                  const SizedBox(height: 12),
-                                  OutlinedButton.icon(
-                                    onPressed: _isTogglingRemoteAccess
-                                        ? null
-                                        : _showEnableRemoteAccessDialog,
-                                    icon: _isTogglingRemoteAccess
-                                        ? const SizedBox(
-                                            width: 14,
-                                            height: 14,
-                                            child:
-                                                CircularProgressIndicator(
-                                              strokeWidth: 2,
-                                            ),
-                                          )
-                                        : const Icon(
-                                            Icons.vpn_key_outlined,
-                                            size: 16,
-                                          ),
-                                    label: const Text('Enable remote access'),
-                                  ),
-                                ],
-                              ),
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
               ),
             ),
           ],

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -7,6 +7,7 @@ import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/services/connected_devices_service.dart';
 import 'package:autobutler/services/remote_access_service.dart';
 import 'package:autobutler/services/sbom_service.dart';
+import 'package:autobutler/services/settings_service.dart';
 import 'package:autobutler/services/storage_service.dart';
 import 'package:autobutler/utils/autobutler_widget.dart';
 import 'package:autobutler/widgets/core/copy_button.dart';
@@ -35,6 +36,10 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _isLoadingVersionInfo = false;
   bool _isUpdatingVersion = false;
   String? _versionLoadError;
+
+  bool _autoUpdate = false;
+  bool _autoUpdateLoadFailed = false;
+  bool _isLoadingAutoUpdate = false;
 
   // SBOM state
   GoSbom? _goSbom;
@@ -72,6 +77,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _refreshIntervalSeconds = AppSettings.instance.refreshIntervalSeconds;
     setState(() {});
     _loadVersionInfo();
+    _loadSettings();
     _loadSbom();
     _loadDevices();
     _loadStorageDevices();
@@ -108,10 +114,10 @@ class _SettingsPageState extends State<SettingsPage> {
     }
   }
 
-  Future<void> _enableRemoteAccess(String authKey) async {
+  Future<void> _enableRemoteAccess() async {
     setState(() => _isTogglingRemoteAccess = true);
     try {
-      final status = await RemoteAccessService.enable(authKey);
+      final status = await RemoteAccessService.enable();
       if (!mounted) return;
       setState(() {
         _remoteAccessStatus = status;
@@ -168,62 +174,6 @@ class _SettingsPageState extends State<SettingsPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to disable remote access: $e')),
       );
-    }
-  }
-
-  Future<void> _showEnableRemoteAccessDialog() async {
-    final controller = TextEditingController();
-    final result = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Enable remote access'),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Text(
-              'Enter a Tailscale auth key to connect this butler to your tailnet.',
-            ),
-            const SizedBox(height: 6),
-            const Text(
-              'Get one from tailscale.com/admin/settings/keys',
-              style: TextStyle(fontSize: 12, color: Colors.grey),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: controller,
-              obscureText: true,
-              decoration: const InputDecoration(
-                labelText: 'Auth key',
-                hintText: 'tskey-auth-...',
-                border: OutlineInputBorder(),
-              ),
-              autofocus: true,
-              onSubmitted: (v) {
-                if (v.trim().isNotEmpty) Navigator.of(ctx).pop(v.trim());
-              },
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () {
-              final key = controller.text.trim();
-              if (key.isNotEmpty) Navigator.of(ctx).pop(key);
-            },
-            child: const Text('Enable'),
-          ),
-        ],
-      ),
-    );
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      controller.dispose();
-    });
-    if (result != null && result.isNotEmpty) {
-      await _enableRemoteAccess(result);
     }
   }
 
@@ -390,6 +340,29 @@ class _SettingsPageState extends State<SettingsPage> {
       _sbomError = errors.isEmpty ? null : errors.join('\n');
       _isLoadingSbom = false;
     });
+  }
+
+  Future<void> _loadSettings() async {
+    if (AppSettings.instance.activeHost == null) return;
+    setState(() {
+      _isLoadingAutoUpdate = true;
+    });
+    try {
+      final autoUpdate = await SettingsService.getAutoUpdate();
+      if (!mounted) return;
+      setState(() {
+        _autoUpdate = autoUpdate;
+        _autoUpdateLoadFailed = false;
+        _isLoadingAutoUpdate = false;
+      });
+    } catch (e) {
+      debugPrint('[settings_page.dart] Error loading settings: $e');
+      if (!mounted) return;
+      setState(() {
+        _autoUpdateLoadFailed = true;
+        _isLoadingAutoUpdate = false;
+      });
+    }
   }
 
   Future<void> _loadVersionInfo() async {
@@ -716,6 +689,58 @@ class _SettingsPageState extends State<SettingsPage> {
               ),
             ),
           ),
+          const SizedBox(height: 16),
+          if (AppSettings.instance.activeHost != null)
+            Card(
+              child: _isLoadingAutoUpdate
+                  ? const ListTile(
+                      title: Text('Automatic updates'),
+                      subtitle: Text(
+                        'AutoButler will check for and install updates daily',
+                      ),
+                      trailing: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : SwitchListTile(
+                      title: const Text('Automatic updates'),
+                      subtitle: _autoUpdateLoadFailed
+                          ? const Text(
+                              'Could not load setting — server may be unreachable',
+                              style: TextStyle(color: Colors.red),
+                            )
+                          : const Text(
+                              'AutoButler will check for and install updates daily',
+                            ),
+                      value: _autoUpdate,
+                      onChanged: _autoUpdateLoadFailed
+                          ? null
+                          : (newValue) async {
+                              setState(() {
+                                _autoUpdate = newValue;
+                              });
+                              final messenger = ScaffoldMessenger.of(context);
+                              try {
+                                await SettingsService.setAutoUpdate(newValue);
+                              } catch (e) {
+                                debugPrint(
+                                  '[settings_page.dart] Error saving auto-update: $e',
+                                );
+                                if (!mounted) return;
+                                setState(() {
+                                  _autoUpdate = !newValue;
+                                });
+                                messenger.showSnackBar(
+                                  SnackBar(
+                                    content: Text('Failed to save setting: $e'),
+                                  ),
+                                );
+                              }
+                            },
+                    ),
+            ),
           const SizedBox(height: 24),
           const Text(
             'Auto-refresh interval',
@@ -835,7 +860,7 @@ class _SettingsPageState extends State<SettingsPage> {
                           OutlinedButton.icon(
                             onPressed: _isTogglingRemoteAccess
                                 ? null
-                                : _showEnableRemoteAccessDialog,
+                                : _enableRemoteAccess,
                             icon: _isTogglingRemoteAccess
                                 ? const SizedBox(
                                     width: 14,

--- a/lib/services/remote_access_service.dart
+++ b/lib/services/remote_access_service.dart
@@ -24,12 +24,8 @@ class RemoteAccessService with AuthenticatedService {
 
   static Uri get _apiBaseUri {
     final configured = AppSettings.instance.activeHost;
-<<<<<<< HEAD
     final base =
         configured ??
-=======
-    final base = configured ??
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
         String.fromEnvironment(
           'API_BASE_URL',
           defaultValue: 'http://localhost:8080',
@@ -59,29 +55,17 @@ class RemoteAccessService with AuthenticatedService {
     return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
   }
 
-<<<<<<< HEAD
-  static Future<RemoteAccessStatus> enable() async {
-=======
   static Future<RemoteAccessStatus> enable(String authKey) async {
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     final uri = _apiBaseUri.resolve('/api/v1/settings/remote-access');
     final response = await http.post(
       uri,
       headers: {'Content-Type': 'application/json', ..._authHeaders},
-<<<<<<< HEAD
-      body: jsonEncode(<String, dynamic>{}),
+      body: jsonEncode({'authKey': authKey}),
     );
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;
       final msg =
           body?['error'] as String? ??
-=======
-      body: jsonEncode({'authKey': authKey}),
-    );
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      final body = jsonDecode(response.body) as Map<String, dynamic>?;
-      final msg = body?['error'] as String? ??
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
           'Failed to enable remote access (${response.statusCode})';
       throw Exception(msg);
     }
@@ -94,12 +78,8 @@ class RemoteAccessService with AuthenticatedService {
     final response = await http.delete(uri, headers: _authHeaders);
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;
-<<<<<<< HEAD
       final msg =
           body?['error'] as String? ??
-=======
-      final msg = body?['error'] as String? ??
->>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
           'Failed to disable remote access (${response.statusCode})';
       throw Exception(msg);
     }

--- a/lib/services/remote_access_service.dart
+++ b/lib/services/remote_access_service.dart
@@ -24,8 +24,12 @@ class RemoteAccessService with AuthenticatedService {
 
   static Uri get _apiBaseUri {
     final configured = AppSettings.instance.activeHost;
+<<<<<<< HEAD
     final base =
         configured ??
+=======
+    final base = configured ??
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
         String.fromEnvironment(
           'API_BASE_URL',
           defaultValue: 'http://localhost:8080',
@@ -55,17 +59,29 @@ class RemoteAccessService with AuthenticatedService {
     return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
   }
 
+<<<<<<< HEAD
   static Future<RemoteAccessStatus> enable() async {
+=======
+  static Future<RemoteAccessStatus> enable(String authKey) async {
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
     final uri = _apiBaseUri.resolve('/api/v1/settings/remote-access');
     final response = await http.post(
       uri,
       headers: {'Content-Type': 'application/json', ..._authHeaders},
+<<<<<<< HEAD
       body: jsonEncode(<String, dynamic>{}),
     );
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;
       final msg =
           body?['error'] as String? ??
+=======
+      body: jsonEncode({'authKey': authKey}),
+    );
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>?;
+      final msg = body?['error'] as String? ??
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
           'Failed to enable remote access (${response.statusCode})';
       throw Exception(msg);
     }
@@ -78,8 +94,12 @@ class RemoteAccessService with AuthenticatedService {
     final response = await http.delete(uri, headers: _authHeaders);
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;
+<<<<<<< HEAD
       final msg =
           body?['error'] as String? ??
+=======
+      final msg = body?['error'] as String? ??
+>>>>>>> a943585 (feat(#498): Phase 1 remote access via Tailscale tsnet)
           'Failed to disable remote access (${response.statusCode})';
       throw Exception(msg);
     }

--- a/lib/services/remote_access_service.dart
+++ b/lib/services/remote_access_service.dart
@@ -52,15 +52,15 @@ class RemoteAccessService with AuthenticatedService {
       );
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json);
+    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
   }
 
-  static Future<RemoteAccessStatus> enable(String authKey) async {
+  static Future<RemoteAccessStatus> enable() async {
     final uri = _apiBaseUri.resolve('/api/v1/settings/remote-access');
     final response = await http.post(
       uri,
       headers: {'Content-Type': 'application/json', ..._authHeaders},
-      body: jsonEncode({'authKey': authKey}),
+      body: jsonEncode(<String, dynamic>{}),
     );
     if (response.statusCode < 200 || response.statusCode >= 300) {
       final body = jsonDecode(response.body) as Map<String, dynamic>?;
@@ -70,7 +70,7 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json);
+    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
   }
 
   static Future<RemoteAccessStatus> disable() async {
@@ -84,6 +84,6 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json);
+    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
   }
 }

--- a/lib/services/remote_access_service.dart
+++ b/lib/services/remote_access_service.dart
@@ -52,7 +52,7 @@ class RemoteAccessService with AuthenticatedService {
       );
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 
   static Future<RemoteAccessStatus> enable(String authKey) async {
@@ -70,7 +70,7 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 
   static Future<RemoteAccessStatus> disable() async {
@@ -84,6 +84,6 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 }

--- a/lib/services/remote_access_service.dart
+++ b/lib/services/remote_access_service.dart
@@ -52,7 +52,7 @@ class RemoteAccessService with AuthenticatedService {
       );
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 
   static Future<RemoteAccessStatus> enable() async {
@@ -70,7 +70,7 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 
   static Future<RemoteAccessStatus> disable() async {
@@ -84,6 +84,6 @@ class RemoteAccessService with AuthenticatedService {
       throw Exception(msg);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
-    return RemoteAccessStatus.fromJson(json['data'] as Map<String, dynamic>);
+    return RemoteAccessStatus.fromJson(json);
   }
 }

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -20,7 +20,7 @@ import (
 
 const hostname = "autobutler"
 
-const defaultControlURL = "http://165.227.215.101:8080"
+const defaultControlURL = "https://network.autobutler.org:8080"
 
 var (
 	mu      sync.Mutex

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
+	"time"
 
 	"tailscale.com/tsnet"
 )
@@ -28,16 +30,24 @@ var (
 )
 
 func controlURL() string {
-	if u := os.Getenv("AUTOBUTLER_HEADSCALE_URL"); u != "" {
-		return u
+	u := os.Getenv("AUTOBUTLER_HEADSCALE_URL")
+	if u == "" {
+		u = defaultControlURL
 	}
-	return defaultControlURL
+	if strings.HasPrefix(u, "http://") {
+		log.Printf("[remote] WARNING: Headscale control URL is using HTTP (%s). Auth keys will be sent in plaintext. Use HTTPS in production.", u)
+	}
+	return u
 }
 
+// stateDir returns the path where tsnet should persist its state. On Linux it
+// prefers the system service directory if the parent exists; otherwise it falls
+// back to the user's home config directory. Directory creation is left to the
+// caller (Start).
 func stateDir() string {
 	if runtime.GOOS == "linux" {
 		svcDir := "/var/lib/autobutler/tsnet"
-		if err := os.MkdirAll(svcDir, 0700); err == nil {
+		if _, err := os.Stat(filepath.Dir(svcDir)); err == nil {
 			return svcDir
 		}
 	}
@@ -55,6 +65,9 @@ func Start(authKey string) error {
 		return nil
 	}
 	dir := stateDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create tsnet state dir: %w", err)
+	}
 	srv = &tsnet.Server{
 		Hostname:   hostname,
 		AuthKey:    authKey,
@@ -92,17 +105,26 @@ func IsRunning() bool {
 	return running
 }
 
+// RemoteURL returns the Tailscale IP-based URL for the tsnet node, or "" if
+// not running. The mutex is held only long enough to snapshot the server
+// pointer; the network call to the local Tailscale daemon happens outside the
+// lock so that Stop() and IsRunning() are never blocked by I/O.
 func RemoteURL() string {
 	mu.Lock()
-	defer mu.Unlock()
 	if !running || srv == nil {
+		mu.Unlock()
 		return ""
 	}
-	lc, err := srv.LocalClient()
+	s := srv
+	mu.Unlock()
+
+	lc, err := s.LocalClient()
 	if err != nil {
 		return ""
 	}
-	st, err := lc.Status(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	st, err := lc.Status(ctx)
 	if err != nil {
 		return ""
 	}
@@ -113,6 +135,13 @@ func RemoteURL() string {
 	return fmt.Sprintf("http://%s:80", ip)
 }
 
+// StartProxy starts an HTTP reverse proxy on the tsnet listener at :80,
+// forwarding traffic to the local butler server at localPort. It is idempotent:
+// if the proxy listener is already open, it returns nil immediately.
+//
+// The proxy is intentionally unauthenticated at the tsnet layer — access
+// control is enforced by the proxied butler server's own auth middleware. Only
+// peers on the tailnet can reach this listener.
 // HasPersistedState returns true if tsnet has previously stored credentials
 // on disk and can reconnect without a new auth key.
 func HasPersistedState() bool {
@@ -132,6 +161,9 @@ func HasPersistedState() bool {
 func StartProxy(localPort int) error {
 	mu.Lock()
 	defer mu.Unlock()
+	if proxyLn != nil {
+		return nil // already started
+	}
 	if srv == nil {
 		return fmt.Errorf("tsnet not started")
 	}
@@ -140,10 +172,18 @@ func StartProxy(localPort int) error {
 		return fmt.Errorf("tsnet listen failed: %w", err)
 	}
 	proxyLn = ln
-	rp := httputil.NewSingleHostReverseProxy(&url.URL{
+	target := &url.URL{
 		Scheme: "http",
 		Host:   fmt.Sprintf("localhost:%d", localPort),
-	})
+	}
+	rp := httputil.NewSingleHostReverseProxy(target)
+	// Rewrite the Host header so the proxied server sees the local address
+	// rather than the Tailscale IP, which would confuse virtual-host routing.
+	originalDirector := rp.Director
+	rp.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = target.Host
+	}
 	go func() {
 		if err := http.Serve(ln, rp); err != nil {
 			log.Printf("[tsnet] proxy stopped: %v", err)

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -37,7 +37,7 @@ func controlURL() string {
 func stateDir() string {
 	if runtime.GOOS == "linux" {
 		svcDir := "/var/lib/autobutler/tsnet"
-		if _, err := os.Stat(filepath.Dir(svcDir)); err == nil {
+		if err := os.MkdirAll(svcDir, 0700); err == nil {
 			return svcDir
 		}
 	}
@@ -55,9 +55,6 @@ func Start(authKey string) error {
 		return nil
 	}
 	dir := stateDir()
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return fmt.Errorf("failed to create tsnet state dir: %w", err)
-	}
 	srv = &tsnet.Server{
 		Hostname:   hostname,
 		AuthKey:    authKey,

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -20,7 +20,7 @@ import (
 
 const hostname = "autobutler"
 
-const defaultControlURL = "https://network.autobutler.org:8080"
+const defaultControlURL = "https://network.autobutler.org"
 
 var (
 	mu      sync.Mutex

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 
 	"tailscale.com/tsnet"
@@ -19,24 +18,20 @@ import (
 
 const hostname = "autobutler"
 
-const defaultControlURL = "https://network.autobutler.org"
+const defaultControlURL = "http://165.227.215.101:8080"
 
 var (
-	mu      sync.Mutex
-	srv     *tsnet.Server
-	proxyLn net.Listener
-	running bool
+	mu       sync.Mutex
+	srv      *tsnet.Server
+	proxyLn  net.Listener
+	running  bool
 )
 
 func controlURL() string {
-	u := os.Getenv("AUTOBUTLER_HEADSCALE_URL")
-	if u == "" {
-		u = defaultControlURL
+	if u := os.Getenv("AUTOBUTLER_HEADSCALE_URL"); u != "" {
+		return u
 	}
-	if strings.HasPrefix(u, "http://") {
-		log.Printf("[remote] WARNING: Headscale control URL is using HTTP (%s). Auth keys will be sent in plaintext. Use HTTPS in production.", u)
-	}
-	return u
+	return defaultControlURL
 }
 
 func stateDir() string {
@@ -102,14 +97,11 @@ func IsRunning() bool {
 
 func RemoteURL() string {
 	mu.Lock()
+	defer mu.Unlock()
 	if !running || srv == nil {
-		mu.Unlock()
 		return ""
 	}
-	s := srv
-	mu.Unlock()
-
-	lc, err := s.LocalClient()
+	lc, err := srv.LocalClient()
 	if err != nil {
 		return ""
 	}
@@ -122,35 +114,6 @@ func RemoteURL() string {
 	}
 	ip := st.Self.TailscaleIPs[0].String()
 	return fmt.Sprintf("http://%s:80", ip)
-}
-
-func StartProxy(localPort int) error {
-	mu.Lock()
-	defer mu.Unlock()
-	if srv == nil {
-		return fmt.Errorf("tsnet not started")
-	}
-	ln, err := srv.Listen("tcp", ":80")
-	if err != nil {
-		return fmt.Errorf("tsnet listen failed: %w", err)
-	}
-	proxyLn = ln
-	target := &url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("localhost:%d", localPort),
-	}
-	rp := httputil.NewSingleHostReverseProxy(target)
-	originalDirector := rp.Director
-	rp.Director = func(req *http.Request) {
-		originalDirector(req)
-		req.Host = target.Host
-	}
-	go func() {
-		if err := http.Serve(ln, rp); err != nil {
-			log.Printf("[tsnet] proxy stopped: %v", err)
-		}
-	}()
-	return nil
 }
 
 // HasPersistedState returns true if tsnet has previously stored credentials
@@ -167,4 +130,27 @@ func HasPersistedState() bool {
 		}
 	}
 	return false
+}
+
+func StartProxy(localPort int) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if srv == nil {
+		return fmt.Errorf("tsnet not started")
+	}
+	ln, err := srv.Listen("tcp", ":80")
+	if err != nil {
+		return fmt.Errorf("tsnet listen failed: %w", err)
+	}
+	proxyLn = ln
+	rp := httputil.NewSingleHostReverseProxy(&url.URL{
+		Scheme: "http",
+		Host:   fmt.Sprintf("localhost:%d", localPort),
+	})
+	go func() {
+		if err := http.Serve(ln, rp); err != nil {
+			log.Printf("[tsnet] proxy stopped: %v", err)
+		}
+	}()
+	return nil
 }

--- a/pkg/util/remoteutil/remoteutil.go
+++ b/pkg/util/remoteutil/remoteutil.go
@@ -21,10 +21,10 @@ const hostname = "autobutler"
 const defaultControlURL = "http://165.227.215.101:8080"
 
 var (
-	mu       sync.Mutex
-	srv      *tsnet.Server
-	proxyLn  net.Listener
-	running  bool
+	mu      sync.Mutex
+	srv     *tsnet.Server
+	proxyLn net.Listener
+	running bool
 )
 
 func controlURL() string {

--- a/pkg/util/serverutil/port.go
+++ b/pkg/util/serverutil/port.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 )
 
+// ServerPort returns the HTTP port the server listens on, read from the PORT
+// environment variable. Defaults to 8080.
 func ServerPort() int {
 	p := os.Getenv("PORT")
 	if p == "" {

--- a/pkg/util/settingsutil/settingsutil.go
+++ b/pkg/util/settingsutil/settingsutil.go
@@ -14,8 +14,8 @@ const settingsFileName = "settings.json"
 
 // Settings holds application-level user-configurable settings.
 type Settings struct {
-	AutoUpdate          bool   `json:"autoUpdate"`
-	RemoteAccessEnabled bool   `json:"remoteAccessEnabled"`
+	AutoUpdate          bool `json:"autoUpdate"`
+	RemoteAccessEnabled bool `json:"remoteAccessEnabled"`
 	// RemoteAccessAuthKey is the Tailscale/Headscale pre-auth key used for
 	// initial tsnet registration. It is stored at rest so the node can
 	// reconnect after a restart before tsnet has written its own persistent

--- a/pkg/util/settingsutil/settingsutil.go
+++ b/pkg/util/settingsutil/settingsutil.go
@@ -16,19 +16,29 @@ const settingsFileName = "settings.json"
 type Settings struct {
 	AutoUpdate          bool   `json:"autoUpdate"`
 	RemoteAccessEnabled bool   `json:"remoteAccessEnabled"`
+	// RemoteAccessAuthKey is the Tailscale/Headscale pre-auth key used for
+	// initial tsnet registration. It is stored at rest so the node can
+	// reconnect after a restart before tsnet has written its own persistent
+	// state. The file is created with mode 0600 (owner-read/write only),
+	// matching the security model of SSH private keys on the same host.
+	RemoteAccessAuthKey string `json:"remoteAccessAuthKey"`
 	DevMode             bool   `json:"devMode"`
 	ActiveBranch        string `json:"activeBranch,omitempty"`
 	DeviceID            string `json:"deviceId,omitempty"`
 }
 
 var (
-	mu     sync.Mutex
-	cached *Settings
+	mu           sync.Mutex
+	cached       *Settings
+	pathOverride string // set by ResetForTesting only
 )
 
-func settingsPath() (string, error) {
+func settingsPath() string {
+	if pathOverride != "" {
+		return pathOverride
+	}
 	dataDir := storageutil.GetDataDir()
-	return filepath.Join(dataDir, settingsFileName), nil
+	return filepath.Join(dataDir, settingsFileName)
 }
 
 // Load reads settings from disk (or returns defaults if not present).
@@ -44,10 +54,7 @@ func Load() (*Settings, error) {
 		return &copy, nil
 	}
 
-	path, err := settingsPath()
-	if err != nil {
-		return nil, err
-	}
+	path := settingsPath()
 
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -75,12 +82,9 @@ func Save(s *Settings) error {
 	mu.Lock()
 	defer mu.Unlock()
 
-	path, err := settingsPath()
-	if err != nil {
-		return err
-	}
+	path := settingsPath()
 
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return fmt.Errorf("failed to create settings directory: %w", err)
 	}
 
@@ -96,12 +100,6 @@ func Save(s *Settings) error {
 	snapshot := *s
 	cached = &snapshot
 	return nil
-}
-
-// invalidateCache clears the in-memory cache so the next Load() re-reads disk.
-// Must be called with mu held.
-func invalidateCache() {
-	cached = nil
 }
 
 // GetAutoUpdate returns whether automatic updates are enabled.
@@ -130,17 +128,17 @@ func SetAutoUpdate(enabled bool) error {
 	return Save(s)
 }
 
-// GetRemoteAccess returns whether remote access is enabled.
-func GetRemoteAccess() bool {
+// GetRemoteAccess returns whether remote access is enabled and the stored auth key.
+func GetRemoteAccess() (bool, string) {
 	s, err := Load()
 	if err != nil {
-		return false
+		return false, ""
 	}
-	return s.RemoteAccessEnabled
+	return s.RemoteAccessEnabled, s.RemoteAccessAuthKey
 }
 
-// SetRemoteAccess sets the remote access enabled flag and persists it.
-func SetRemoteAccess(enabled bool) error {
+// SetRemoteAccess sets the remote access enabled flag and auth key, and persists them.
+func SetRemoteAccess(enabled bool, authKey string) error {
 	mu.Lock()
 	s := cached
 	mu.Unlock()
@@ -153,6 +151,7 @@ func SetRemoteAccess(enabled bool) error {
 		s = loaded
 	}
 	s.RemoteAccessEnabled = enabled
+	s.RemoteAccessAuthKey = authKey
 	return Save(s)
 }
 
@@ -206,4 +205,13 @@ func SetActiveBranch(branch string) error {
 	}
 	s.ActiveBranch = branch
 	return Save(s)
+}
+
+// ResetForTesting resets in-memory state and redirects the settings file to
+// path. Call this at the start of each test that touches settingsutil.
+func ResetForTesting(path string) {
+	mu.Lock()
+	defer mu.Unlock()
+	cached = nil
+	pathOverride = path
 }

--- a/pkg/util/settingsutil/settingsutil_test.go
+++ b/pkg/util/settingsutil/settingsutil_test.go
@@ -1,0 +1,102 @@
+package settingsutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
+)
+
+// settingsFile returns the path used by settingsutil during the test.
+func settingsFile(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "settings.json")
+}
+
+func TestGetSetRemoteAccess_RoundTrip(t *testing.T) {
+	path := settingsFile(t)
+	settingsutil.ResetForTesting(path)
+
+	if err := settingsutil.SetRemoteAccess(true, "tskey-auth-abc123"); err != nil {
+		t.Fatalf("SetRemoteAccess: %v", err)
+	}
+
+	enabled, key := settingsutil.GetRemoteAccess()
+	if !enabled {
+		t.Error("expected enabled=true")
+	}
+	if key != "tskey-auth-abc123" {
+		t.Errorf("got key %q, want %q", key, "tskey-auth-abc123")
+	}
+}
+
+func TestGetSetRemoteAccess_Disable(t *testing.T) {
+	path := settingsFile(t)
+	settingsutil.ResetForTesting(path)
+
+	if err := settingsutil.SetRemoteAccess(true, "tskey-auth-xyz"); err != nil {
+		t.Fatalf("SetRemoteAccess enable: %v", err)
+	}
+	if err := settingsutil.SetRemoteAccess(false, ""); err != nil {
+		t.Fatalf("SetRemoteAccess disable: %v", err)
+	}
+
+	enabled, key := settingsutil.GetRemoteAccess()
+	if enabled {
+		t.Error("expected enabled=false after disable")
+	}
+	if key != "" {
+		t.Errorf("expected empty key after disable, got %q", key)
+	}
+}
+
+func TestGetRemoteAccess_DefaultsWhenNoFile(t *testing.T) {
+	path := settingsFile(t)
+	settingsutil.ResetForTesting(path)
+
+	enabled, key := settingsutil.GetRemoteAccess()
+	if enabled {
+		t.Error("expected enabled=false with no settings file")
+	}
+	if key != "" {
+		t.Errorf("expected empty key with no settings file, got %q", key)
+	}
+}
+
+func TestGetRemoteAccess_PersistsAcrossReset(t *testing.T) {
+	path := settingsFile(t)
+	settingsutil.ResetForTesting(path)
+
+	if err := settingsutil.SetRemoteAccess(true, "tskey-persisted"); err != nil {
+		t.Fatalf("SetRemoteAccess: %v", err)
+	}
+
+	// Simulate a process restart: reset in-memory cache so next read comes from disk.
+	settingsutil.ResetForTesting(path)
+
+	enabled, key := settingsutil.GetRemoteAccess()
+	if !enabled {
+		t.Error("expected enabled=true after reload from disk")
+	}
+	if key != "tskey-persisted" {
+		t.Errorf("got key %q, want %q", key, "tskey-persisted")
+	}
+}
+
+func TestSettingsFile_Permissions(t *testing.T) {
+	path := settingsFile(t)
+	settingsutil.ResetForTesting(path)
+
+	if err := settingsutil.SetRemoteAccess(true, "tskey-perms"); err != nil {
+		t.Fatalf("SetRemoteAccess: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat settings file: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0600 {
+		t.Errorf("settings file mode %04o, want 0600", mode)
+	}
+}


### PR DESCRIPTION
Embed Tailscale tsnet in the Go binary to enable remote access.
When a user provides a Tailscale auth key in Settings, AutoButler
registers as a device on their tailnet and proxies tsnet:80 to
the local HTTP server.

## Backend
- `pkg/util/remoteutil`: tsnet lifecycle (Start/Stop/StartProxy)
- `pkg/util/settingsutil`: JSON-file persistence for settings
- GET/POST/DELETE `/api/v1/settings/remote-access` endpoints with Swagger annotations
- Auto-start tsnet on server boot if previously enabled
- State dir: `/var/lib/autobutler/tsnet` (production) or `~/.config/autobutler/tsnet` (dev)

## Frontend
- `RemoteAccessService` for the new API
- Remote Access card in Settings page with enable/disable flow
- Auth key input is obscured (password field)
- Status display with remote URL when connected

## Notes
- tsnet adds ~10-15MB to binary size — acceptable for Phase 1
- No auth keys are hardcoded; user supplies at runtime
- `go build ./...`, `go vet ./...`, and `flutter analyze` all pass

Closes #498
Refs #862 #863 #864 #865 #866