### PR TITLE
feat: provisioning service — branch artifact proxy endpoints (#886)

### DIFF
--- a/cmd/provisioning/main.go
+++ b/cmd/provisioning/main.go
@@ -24,13 +24,13 @@ var (
 )
 
 const (
-	ghAPIBase     = "https://api.github.com"
-	repoPath      = "autobutler-org/autobutler"
-	artifactName  = "autobutler-linux-arm64"
-	cacheTTL      = 60 * time.Second
-	rateLimit     = 5
-	rateWindow    = time.Hour
-	listenAddr    = ":8090"
+	ghAPIBase    = "https://api.github.com"
+	repoPath     = "autobutler-org/autobutler"
+	artifactName = "autobutler-linux-arm64"
+	cacheTTL     = 60 * time.Second
+	rateLimit    = 5
+	rateWindow   = time.Hour
+	listenAddr   = ":8090"
 )
 
 type ipRateLimiter struct {
@@ -92,12 +92,12 @@ type ghArtifactsResponse struct {
 }
 
 type ghArtifact struct {
-	ID                 int64  `json:"id"`
-	Name               string `json:"name"`
-	WorkflowRunID      int64  `json:"workflow_run_id,omitempty"`
-	CreatedAt          string `json:"created_at"`
-	Expired            bool   `json:"expired"`
-	WorkflowRun        *ghArtifactWorkflowRun `json:"workflow_run,omitempty"`
+	ID            int64                  `json:"id"`
+	Name          string                 `json:"name"`
+	WorkflowRunID int64                  `json:"workflow_run_id,omitempty"`
+	CreatedAt     string                 `json:"created_at"`
+	Expired       bool                   `json:"expired"`
+	WorkflowRun   *ghArtifactWorkflowRun `json:"workflow_run,omitempty"`
 }
 
 type ghArtifactWorkflowRun struct {

--- a/cmd/provisioning/main.go
+++ b/cmd/provisioning/main.go
@@ -30,7 +30,7 @@ const (
 	cacheTTL     = 60 * time.Second
 	rateLimit    = 5
 	rateWindow   = time.Hour
-	listenAddr   = ":8090"
+	listenAddr   = ":8081"
 )
 
 type ipRateLimiter struct {
@@ -55,6 +55,25 @@ func (r *ipRateLimiter) allow(ip string) bool {
 	}
 	r.hits[ip] = append(recent, now)
 	return true
+}
+
+func (r *ipRateLimiter) prune() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cutoff := time.Now().Add(-rateWindow)
+	for ip, times := range r.hits {
+		var recent []time.Time
+		for _, t := range times {
+			if t.After(cutoff) {
+				recent = append(recent, t)
+			}
+		}
+		if len(recent) == 0 {
+			delete(r.hits, ip)
+		} else {
+			r.hits[ip] = recent
+		}
+	}
 }
 
 type cache struct {
@@ -121,29 +140,20 @@ func main() {
 	}
 	githubToken = os.Getenv("GITHUB_TOKEN")
 
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			rateLimiter.prune()
+		}
+	}()
+
 	mux := http.NewServeMux()
-	mux.HandleFunc("/provision", handleProvision)
 	mux.HandleFunc("/artifacts", handleArtifacts)
 	mux.HandleFunc("/artifacts/", handleArtifactsPrefix)
 
 	log.Printf("provisioning service listening on %s", listenAddr)
 	log.Fatal(http.ListenAndServe(listenAddr, mux))
-}
-
-func handleProvision(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !authenticate(w, r) {
-		return
-	}
-	if !rateCheck(w, r) {
-		return
-	}
-	// Placeholder — existing provisioning logic for Headscale pre-auth keys
-	// would go here. Kept as a stub for this PR since it's not part of #886.
-	jsonResponse(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func handleArtifacts(w http.ResponseWriter, r *http.Request) {
@@ -346,7 +356,8 @@ func downloadArtifactZip(artifactID int64) (string, error) {
 		return "", err
 	}
 
-	if _, err := io.Copy(tmp, resp.Body); err != nil {
+	const maxArtifactBytes = 200 * 1024 * 1024
+	if _, err := io.Copy(tmp, io.LimitReader(resp.Body, maxArtifactBytes)); err != nil {
 		tmp.Close()
 		os.Remove(tmp.Name())
 		return "", err

--- a/cmd/provisioning/main.go
+++ b/cmd/provisioning/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"archive/zip"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -236,9 +239,18 @@ func handleArtifactDownload(w http.ResponseWriter, r *http.Request, branch strin
 	}
 	defer binary.Close()
 
+	binaryBytes, err := io.ReadAll(binary)
+	if err != nil {
+		log.Printf("error reading binary from artifact %d: %v", target.ArtifactID, err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "failed to read binary"})
+		return
+	}
+
+	hash := sha256.Sum256(binaryBytes)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", `attachment; filename="autobutler"`)
-	io.Copy(w, binary)
+	w.Header().Set("X-Content-SHA256", hex.EncodeToString(hash[:]))
+	w.Write(binaryBytes)
 }
 
 func fetchBranchArtifacts() ([]branchArtifact, error) {
@@ -413,7 +425,7 @@ func ghGet(url string, target interface{}) error {
 
 func authenticate(w http.ResponseWriter, r *http.Request) bool {
 	secret := r.Header.Get("X-Provisioning-Secret")
-	if secret == "" || secret != provisioningSecret {
+	if secret == "" || subtle.ConstantTimeCompare([]byte(secret), []byte(provisioningSecret)) != 1 {
 		jsonResponse(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return false
 	}

--- a/cmd/provisioning/main.go
+++ b/cmd/provisioning/main.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	provisioningSecret string
+	githubToken        string
+	rateLimiter        = &ipRateLimiter{hits: make(map[string][]time.Time)}
+	artifactCache      = &cache{}
+)
+
+const (
+	ghAPIBase     = "https://api.github.com"
+	repoPath      = "autobutler-org/autobutler"
+	artifactName  = "autobutler-linux-arm64"
+	cacheTTL      = 60 * time.Second
+	rateLimit     = 5
+	rateWindow    = time.Hour
+	listenAddr    = ":8090"
+)
+
+type ipRateLimiter struct {
+	mu   sync.Mutex
+	hits map[string][]time.Time
+}
+
+func (r *ipRateLimiter) allow(ip string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	now := time.Now()
+	cutoff := now.Add(-rateWindow)
+	var recent []time.Time
+	for _, t := range r.hits[ip] {
+		if t.After(cutoff) {
+			recent = append(recent, t)
+		}
+	}
+	if len(recent) >= rateLimit {
+		r.hits[ip] = recent
+		return false
+	}
+	r.hits[ip] = append(recent, now)
+	return true
+}
+
+type cache struct {
+	mu        sync.Mutex
+	data      []branchArtifact
+	fetchedAt time.Time
+}
+
+func (c *cache) get() ([]branchArtifact, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.data != nil && time.Since(c.fetchedAt) < cacheTTL {
+		return c.data, true
+	}
+	return nil, false
+}
+
+func (c *cache) set(data []branchArtifact) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = data
+	c.fetchedAt = time.Now()
+}
+
+type branchArtifact struct {
+	Branch     string `json:"branch"`
+	PRNumber   int    `json:"pr_number,omitempty"`
+	PRTitle    string `json:"pr_title,omitempty"`
+	BuiltAt    string `json:"built_at"`
+	ArtifactID int64  `json:"artifact_id"`
+}
+
+type ghArtifactsResponse struct {
+	Artifacts []ghArtifact `json:"artifacts"`
+}
+
+type ghArtifact struct {
+	ID                 int64  `json:"id"`
+	Name               string `json:"name"`
+	WorkflowRunID      int64  `json:"workflow_run_id,omitempty"`
+	CreatedAt          string `json:"created_at"`
+	Expired            bool   `json:"expired"`
+	WorkflowRun        *ghArtifactWorkflowRun `json:"workflow_run,omitempty"`
+}
+
+type ghArtifactWorkflowRun struct {
+	ID         int64  `json:"id"`
+	HeadBranch string `json:"head_branch"`
+}
+
+type ghWorkflowRun struct {
+	HeadBranch string `json:"head_branch"`
+}
+
+type ghPullRequest struct {
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+}
+
+func main() {
+	provisioningSecret = os.Getenv("PROVISIONING_SECRET")
+	if provisioningSecret == "" {
+		log.Fatal("PROVISIONING_SECRET env var is required")
+	}
+	githubToken = os.Getenv("GITHUB_TOKEN")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/provision", handleProvision)
+	mux.HandleFunc("/artifacts", handleArtifacts)
+	mux.HandleFunc("/artifacts/", handleArtifactsPrefix)
+
+	log.Printf("provisioning service listening on %s", listenAddr)
+	log.Fatal(http.ListenAndServe(listenAddr, mux))
+}
+
+func handleProvision(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !authenticate(w, r) {
+		return
+	}
+	if !rateCheck(w, r) {
+		return
+	}
+	// Placeholder — existing provisioning logic for Headscale pre-auth keys
+	// would go here. Kept as a stub for this PR since it's not part of #886.
+	jsonResponse(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleArtifacts(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !authenticate(w, r) {
+		return
+	}
+	if !requireGitHubToken(w) {
+		return
+	}
+	if !rateCheck(w, r) {
+		return
+	}
+
+	artifacts, err := fetchBranchArtifacts()
+	if err != nil {
+		log.Printf("error fetching artifacts: %v", err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch artifacts"})
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(artifacts)
+}
+
+func handleArtifactsPrefix(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/artifacts/")
+
+	if !strings.HasSuffix(path, "/latest") {
+		http.NotFound(w, r)
+		return
+	}
+
+	branch := strings.TrimSuffix(path, "/latest")
+	if branch == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !authenticate(w, r) {
+		return
+	}
+	if !requireGitHubToken(w) {
+		return
+	}
+	if !rateCheck(w, r) {
+		return
+	}
+
+	handleArtifactDownload(w, r, branch)
+}
+
+func handleArtifactDownload(w http.ResponseWriter, r *http.Request, branch string) {
+	artifacts, err := fetchBranchArtifacts()
+	if err != nil {
+		log.Printf("error fetching artifacts: %v", err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch artifacts"})
+		return
+	}
+
+	var target *branchArtifact
+	for i := range artifacts {
+		if artifacts[i].Branch == branch {
+			target = &artifacts[i]
+			break
+		}
+	}
+	if target == nil {
+		jsonResponse(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("no artifact found for branch %q", branch)})
+		return
+	}
+
+	zipData, err := downloadArtifactZip(target.ArtifactID)
+	if err != nil {
+		log.Printf("error downloading artifact %d: %v", target.ArtifactID, err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "failed to download artifact"})
+		return
+	}
+	defer os.Remove(zipData)
+
+	binary, err := extractBinaryFromZip(zipData)
+	if err != nil {
+		log.Printf("error extracting binary from artifact %d: %v", target.ArtifactID, err)
+		jsonResponse(w, http.StatusInternalServerError, map[string]string{"error": "failed to extract binary"})
+		return
+	}
+	defer binary.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", `attachment; filename="autobutler"`)
+	io.Copy(w, binary)
+}
+
+func fetchBranchArtifacts() ([]branchArtifact, error) {
+	if cached, ok := artifactCache.get(); ok {
+		return cached, nil
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/actions/artifacts?per_page=100&name=%s", ghAPIBase, repoPath, artifactName)
+	var artResp ghArtifactsResponse
+	if err := ghGet(url, &artResp); err != nil {
+		return nil, fmt.Errorf("fetching artifacts: %w", err)
+	}
+
+	branchMap := make(map[string]ghArtifact)
+	for _, a := range artResp.Artifacts {
+		if a.Expired {
+			continue
+		}
+
+		var branch string
+		if a.WorkflowRun != nil && a.WorkflowRun.HeadBranch != "" {
+			branch = a.WorkflowRun.HeadBranch
+		} else {
+			runURL := fmt.Sprintf("%s/repos/%s/actions/runs/%d", ghAPIBase, repoPath, a.WorkflowRunID)
+			var run ghWorkflowRun
+			if err := ghGet(runURL, &run); err != nil {
+				log.Printf("warning: failed to fetch run %d: %v", a.WorkflowRunID, err)
+				continue
+			}
+			branch = run.HeadBranch
+		}
+
+		if branch == "" {
+			continue
+		}
+
+		if existing, ok := branchMap[branch]; !ok || a.CreatedAt > existing.CreatedAt {
+			branchMap[branch] = a
+		}
+	}
+
+	var results []branchArtifact
+	for branch, a := range branchMap {
+		ba := branchArtifact{
+			Branch:     branch,
+			BuiltAt:    a.CreatedAt,
+			ArtifactID: a.ID,
+		}
+
+		prURL := fmt.Sprintf("%s/repos/%s/pulls?state=open&head=%s:%s", ghAPIBase, repoPath, "autobutler-org", branch)
+		var prs []ghPullRequest
+		if err := ghGet(prURL, &prs); err == nil && len(prs) > 0 {
+			ba.PRNumber = prs[0].Number
+			ba.PRTitle = prs[0].Title
+		}
+
+		results = append(results, ba)
+	}
+
+	artifactCache.set(results)
+	return results, nil
+}
+
+func downloadArtifactZip(artifactID int64) (string, error) {
+	url := fmt.Sprintf("%s/repos/%s/actions/artifacts/%d/zip", ghAPIBase, repoPath, artifactID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+githubToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return nil
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("downloading zip: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("github returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	tmp, err := os.CreateTemp("", "artifact-*.zip")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
+		return "", err
+	}
+	tmp.Close()
+
+	return tmp.Name(), nil
+}
+
+func extractBinaryFromZip(zipPath string) (io.ReadCloser, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening zip: %w", err)
+	}
+
+	for _, f := range r.File {
+		if f.Name == artifactName || (!strings.Contains(f.Name, "/") && f.FileInfo().Mode()&0111 != 0) {
+			rc, err := f.Open()
+			if err != nil {
+				r.Close()
+				return nil, fmt.Errorf("opening zip entry %q: %w", f.Name, err)
+			}
+			return &zipEntryReader{rc: rc, closer: r}, nil
+		}
+	}
+
+	if len(r.File) > 0 {
+		f := r.File[0]
+		rc, err := f.Open()
+		if err != nil {
+			r.Close()
+			return nil, fmt.Errorf("opening zip entry %q: %w", f.Name, err)
+		}
+		return &zipEntryReader{rc: rc, closer: r}, nil
+	}
+
+	r.Close()
+	return nil, fmt.Errorf("no binary found in zip")
+}
+
+type zipEntryReader struct {
+	rc     io.ReadCloser
+	closer io.Closer
+}
+
+func (z *zipEntryReader) Read(p []byte) (int, error) {
+	return z.rc.Read(p)
+}
+
+func (z *zipEntryReader) Close() error {
+	z.rc.Close()
+	return z.closer.Close()
+}
+
+func ghGet(url string, target interface{}) error {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+githubToken)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("github API %s returned %d: %s", url, resp.StatusCode, string(body))
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func authenticate(w http.ResponseWriter, r *http.Request) bool {
+	secret := r.Header.Get("X-Provisioning-Secret")
+	if secret == "" || secret != provisioningSecret {
+		jsonResponse(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return false
+	}
+	return true
+}
+
+func requireGitHubToken(w http.ResponseWriter) bool {
+	if githubToken == "" {
+		jsonResponse(w, http.StatusServiceUnavailable, map[string]string{"error": "github token not configured"})
+		return false
+	}
+	return true
+}
+
+func rateCheck(w http.ResponseWriter, r *http.Request) bool {
+	ip := r.RemoteAddr
+	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+		ip = strings.Split(fwd, ",")[0]
+	}
+	if !rateLimiter.allow(strings.TrimSpace(ip)) {
+		jsonResponse(w, http.StatusTooManyRequests, map[string]string{"error": "rate limit exceeded"})
+		return false
+	}
+	return true
+}
+
+func jsonResponse(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}


### PR DESCRIPTION
## Summary

Add two new endpoints to the provisioning service that proxy GitHub Actions build artifacts for PR branches, enabling AutoButler devices to update to branch-specific builds.

### New Endpoints

**`GET /artifacts`** — Returns a JSON list of available branch artifacts with PR metadata:
- Queries GitHub Actions API for `autobutler-linux-arm64` artifacts
- Resolves branch from workflow run, fetches open PR info
- Groups by branch, keeps most recent artifact per branch
- Cached in-memory for 60 seconds

**`GET /artifacts/{branch}/latest`** — Downloads and streams the arm64 binary:
- Finds the most recent artifact for the given branch
- Downloads the artifact zip from GitHub, extracts the binary
- Streams to client with `Content-Type: application/octet-stream`
- Handles branch names with slashes (e.g. `feat/886-provisioning-artifacts`)

### Auth & Safety
- Both endpoints require `X-Provisioning-Secret` header
- Both require `GITHUB_TOKEN` env var (`actions:read` scope) — returns 503 if not set
- Rate limited to 5 requests/hour per IP

### New Env Var
- `GITHUB_TOKEN` — GitHub personal access token with `actions:read` scope

Closes #886