### PR TITLE
feat: Flutter UI — branch selector and deploy flow (#887)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -923,6 +923,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/settings/dev-mode": {
+            "get": {
+                "description": "Returns whether dev mode is enabled",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Get dev mode status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_settings.DevModeResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/storage/devices/backup": {
             "post": {
                 "description": "Begin a backup to a device",
@@ -1240,6 +1260,41 @@ const docTemplate = `{
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/version/branches": {
+            "get": {
+                "description": "Returns available PR branch artifacts from the provisioning service. Requires dev mode.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "version"
+                ],
+                "summary": "List available branch builds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v1_version.BranchBuild"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Dev mode required",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "502": {
+                        "description": "Provisioning service error",
                         "schema": {
                             "$ref": "#/definitions/serverutil.Response"
                         }
@@ -1635,6 +1690,34 @@ const docTemplate = `{
                 },
                 "size": {
                     "type": "integer"
+                }
+            }
+        },
+        "v1_settings.DevModeResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1_version.BranchBuild": {
+            "type": "object",
+            "properties": {
+                "artifactId": {
+                    "type": "integer"
+                },
+                "branch": {
+                    "type": "string"
+                },
+                "builtAt": {
+                    "type": "string"
+                },
+                "prNumber": {
+                    "type": "integer"
+                },
+                "prTitle": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -912,6 +912,26 @@
                 }
             }
         },
+        "/settings/dev-mode": {
+            "get": {
+                "description": "Returns whether dev mode is enabled",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "settings"
+                ],
+                "summary": "Get dev mode status",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_settings.DevModeResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/storage/devices/backup": {
             "post": {
                 "description": "Begin a backup to a device",
@@ -1229,6 +1249,41 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/version/branches": {
+            "get": {
+                "description": "Returns available PR branch artifacts from the provisioning service. Requires dev mode.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "version"
+                ],
+                "summary": "List available branch builds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v1_version.BranchBuild"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Dev mode required",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "502": {
+                        "description": "Provisioning service error",
                         "schema": {
                             "$ref": "#/definitions/serverutil.Response"
                         }
@@ -1624,6 +1679,34 @@
                 },
                 "size": {
                     "type": "integer"
+                }
+            }
+        },
+        "v1_settings.DevModeResponse": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "v1_version.BranchBuild": {
+            "type": "object",
+            "properties": {
+                "artifactId": {
+                    "type": "integer"
+                },
+                "branch": {
+                    "type": "string"
+                },
+                "builtAt": {
+                    "type": "string"
+                },
+                "prNumber": {
+                    "type": "integer"
+                },
+                "prTitle": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -196,6 +196,24 @@ definitions:
       size:
         type: integer
     type: object
+  v1_settings.DevModeResponse:
+    properties:
+      enabled:
+        type: boolean
+    type: object
+  v1_version.BranchBuild:
+    properties:
+      artifactId:
+        type: integer
+      branch:
+        type: string
+      builtAt:
+        type: string
+      prNumber:
+        type: integer
+      prTitle:
+        type: string
+    type: object
   v1_version.SbomDependencyJSON:
     properties:
       path:
@@ -866,6 +884,19 @@ paths:
       summary: Get software bill of materials
       tags:
       - version
+  /settings/dev-mode:
+    get:
+      description: Returns whether dev mode is enabled
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1_settings.DevModeResponse'
+      summary: Get dev mode status
+      tags:
+      - settings
   /storage/devices/backup:
     post:
       description: Begin a backup to a device
@@ -1079,6 +1110,30 @@ paths:
           schema:
             $ref: '#/definitions/serverutil.Response'
       summary: List available versions
+      tags:
+      - version
+  /version/branches:
+    get:
+      description: Returns available PR branch artifacts from the provisioning service.
+        Requires dev mode.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/v1_version.BranchBuild'
+            type: array
+        "403":
+          description: Dev mode required
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "502":
+          description: Provisioning service error
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: List available branch builds
       tags:
       - version
   /version/latest:

--- a/internal/server/api/v1/settings/get_dev_mode.go
+++ b/internal/server/api/v1/settings/get_dev_mode.go
@@ -1,0 +1,29 @@
+package v1_settings
+
+import (
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
+	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
+
+	"github.com/gin-gonic/gin"
+)
+
+type DevModeResponse struct {
+	Enabled bool `json:"enabled"`
+}
+
+// getDevMode godoc
+// @Summary Get dev mode status
+// @Description Returns whether dev mode is enabled
+// @Tags settings
+// @Produce json
+// @Success 200 {object} DevModeResponse
+// @Router /settings/dev-mode [get]
+func getDevMode(c *gin.Context) *serverutil.Response {
+	return serverutil.Ok().WithData(DevModeResponse{
+		Enabled: settingsutil.GetDevMode(),
+	})
+}
+
+var getDevModeRoute = serverutil.ApiRoute(
+	"GET", "/settings/dev-mode", getDevMode,
+)

--- a/internal/server/api/v1/settings/v1_settings.go
+++ b/internal/server/api/v1/settings/v1_settings.go
@@ -1,0 +1,15 @@
+package v1_settings
+
+import "github.com/autobutler-org/autobutler/pkg/util/serverutil"
+
+type router struct{}
+
+func NewRouter() serverutil.Router {
+	return &router{}
+}
+
+func (r *router) Routes() []*serverutil.Route {
+	return []*serverutil.Route{
+		getDevModeRoute,
+	}
+}

--- a/internal/server/api/v1/version/list_branches.go
+++ b/internal/server/api/v1/version/list_branches.go
@@ -61,7 +61,8 @@ func listBranches(c *gin.Context) *serverutil.Response {
 		req.Header.Set("X-Provisioning-Secret", secret)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return serverutil.NewResponse().WithStatusCode(http.StatusBadGateway).WithError(fmt.Errorf("provisioning service unavailable: %w", err))
 	}

--- a/internal/server/api/v1/version/list_branches.go
+++ b/internal/server/api/v1/version/list_branches.go
@@ -1,0 +1,85 @@
+package v1_version
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
+	"github.com/autobutler-org/autobutler/pkg/util/settingsutil"
+
+	"github.com/gin-gonic/gin"
+)
+
+type BranchBuild struct {
+	Branch     string    `json:"branch"`
+	PRNumber   int       `json:"prNumber"`
+	PRTitle    string    `json:"prTitle"`
+	BuiltAt    time.Time `json:"builtAt"`
+	ArtifactID int64     `json:"artifactId"`
+}
+
+const defaultProvisioningURL = "http://165.227.215.101:8081"
+
+func getProvisioningURL() string {
+	if url := os.Getenv("AUTOBUTLER_PROVISIONING_URL"); url != "" {
+		return url
+	}
+	return defaultProvisioningURL
+}
+
+func getProvisioningSecret() string {
+	return os.Getenv("AUTOBUTLER_PROVISIONING_SECRET")
+}
+
+// listBranches godoc
+// @Summary List available branch builds
+// @Description Returns available PR branch artifacts from the provisioning service. Requires dev mode.
+// @Tags version
+// @Produce json
+// @Success 200 {array} BranchBuild
+// @Failure 403 {object} serverutil.Response "Dev mode required"
+// @Failure 502 {object} serverutil.Response "Provisioning service error"
+// @Router /version/branches [get]
+func listBranches(c *gin.Context) *serverutil.Response {
+	if !settingsutil.GetDevMode() {
+		return serverutil.Forbidden(errors.New("dev mode required"))
+	}
+
+	url := fmt.Sprintf("%s/artifacts", getProvisioningURL())
+	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, url, nil)
+	if err != nil {
+		return serverutil.NewResponse().WithStatusCode(http.StatusBadGateway).WithError(fmt.Errorf("failed to create request: %w", err))
+	}
+
+	secret := getProvisioningSecret()
+	if secret != "" {
+		req.Header.Set("X-Provisioning-Secret", secret)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return serverutil.NewResponse().WithStatusCode(http.StatusBadGateway).WithError(fmt.Errorf("provisioning service unavailable: %w", err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return serverutil.NewResponse().WithStatusCode(http.StatusBadGateway).WithError(fmt.Errorf("provisioning service returned %d: %s", resp.StatusCode, string(body)))
+	}
+
+	var builds []BranchBuild
+	if err := json.NewDecoder(resp.Body).Decode(&builds); err != nil {
+		return serverutil.NewResponse().WithStatusCode(http.StatusBadGateway).WithError(fmt.Errorf("failed to parse provisioning response: %w", err))
+	}
+
+	return serverutil.Ok().WithData(builds)
+}
+
+var listBranchesRoute = serverutil.ApiRoute(
+	"GET", "/version/branches", listBranches,
+)

--- a/internal/server/api/v1/version/v1_version.go
+++ b/internal/server/api/v1/version/v1_version.go
@@ -19,6 +19,7 @@ func (r *router) Routes() []*serverutil.Route {
 		getInstalledVersionRoute,
 		getLatestVersionRoute,
 		getSbomRoute,
+		listBranchesRoute,
 		listVersionsRoute,
 		updateToLatestRoute,
 	}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -13,6 +13,7 @@ import (
 	v1_metrics "github.com/autobutler-org/autobutler/internal/server/api/v1/metrics"
 	v1_migration "github.com/autobutler-org/autobutler/internal/server/api/v1/migration"
 	v1_photos "github.com/autobutler-org/autobutler/internal/server/api/v1/photos"
+	v1_settings "github.com/autobutler-org/autobutler/internal/server/api/v1/settings"
 	v1_smb "github.com/autobutler-org/autobutler/internal/server/api/v1/smb"
 	v1_storage "github.com/autobutler-org/autobutler/internal/server/api/v1/storage"
 	v1_thumbnails "github.com/autobutler-org/autobutler/internal/server/api/v1/thumbnails"
@@ -43,6 +44,7 @@ func setupRouters(engine *gin.Engine, systemCollector *system.Collector) {
 		v1_metrics.NewRouter(),
 		v1_migration.NewRouter(),
 		v1_photos.NewRouter(),
+		v1_settings.NewRouter(),
 		v1_storage.NewRouter(),
 		v1_thumbnails.NewRouter(),
 		v1_smb.NewRouter(),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -5,8 +5,10 @@ import 'package:autobutler/services/auth_service.dart';
 import 'package:autobutler/services/health_service.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/services/connected_devices_service.dart';
+import 'package:autobutler/services/branch_service.dart';
 import 'package:autobutler/services/sbom_service.dart';
 import 'package:autobutler/services/storage_service.dart';
+import 'package:autobutler/widgets/settings/branch_testing_section.dart';
 import 'package:autobutler/utils/autobutler_widget.dart';
 import 'package:autobutler/widgets/core/copy_button.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
@@ -43,6 +45,8 @@ class _SettingsPageState extends State<SettingsPage> {
 
   int _refreshIntervalSeconds = 15;
 
+  bool _devModeEnabled = false;
+
   // Connected devices state
   List<ConnectedDevice> _connectedDevices = [];
   bool _isLoadingDevices = false;
@@ -69,6 +73,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _loadSbom();
     _loadDevices();
     _loadStorageDevices();
+    _loadDevMode();
   }
 
   Future<void> _loadDevices() async {
@@ -198,6 +203,21 @@ class _SettingsPageState extends State<SettingsPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('Failed to rename device: $e')));
+    }
+  }
+
+  Future<void> _loadDevMode() async {
+    if (AppSettings.instance.activeHost == null) {
+      setState(() => _devModeEnabled = false);
+      return;
+    }
+    try {
+      final enabled = await BranchService.isDevModeEnabled();
+      if (!mounted) return;
+      setState(() => _devModeEnabled = enabled);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _devModeEnabled = false);
     }
   }
 
@@ -854,6 +874,11 @@ class _SettingsPageState extends State<SettingsPage> {
           _NetworkDriveCard(host: AppSettings.instance.activeHost),
 
           const SizedBox(height: 24),
+
+          if (_devModeEnabled && AppSettings.instance.activeHost != null) ...[
+            BranchTestingSection(currentVersion: _installedVersion),
+            const SizedBox(height: 24),
+          ],
 
           const _InfoSectionHeader(label: 'Software Bill of Materials'),
           const SizedBox(height: 8),

--- a/lib/services/base_service.dart
+++ b/lib/services/base_service.dart
@@ -4,7 +4,8 @@ import 'package:flutter/foundation.dart';
 mixin ApiBaseUri {
   static Uri get apiBaseUri {
     final configured = AppSettings.instance.activeHost;
-    final base = configured ??
+    final base =
+        configured ??
         const String.fromEnvironment(
           'API_BASE_URL',
           defaultValue: 'http://localhost:8080',

--- a/lib/services/base_service.dart
+++ b/lib/services/base_service.dart
@@ -1,0 +1,22 @@
+import 'package:autobutler/services/app_settings.dart';
+import 'package:flutter/foundation.dart';
+
+mixin ApiBaseUri {
+  static Uri get apiBaseUri {
+    final configured = AppSettings.instance.activeHost;
+    final base = configured ??
+        const String.fromEnvironment(
+          'API_BASE_URL',
+          defaultValue: 'http://localhost:8080',
+        );
+    final uri = Uri.parse(base);
+    final isLoopback =
+        uri.host == 'localhost' || uri.host == '127.0.0.1' || uri.host == '::1';
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.android &&
+        isLoopback) {
+      return uri.replace(host: '10.0.2.2');
+    }
+    return uri;
+  }
+}

--- a/lib/services/branch_service.dart
+++ b/lib/services/branch_service.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+
+import 'package:autobutler/services/app_settings.dart';
+import 'package:autobutler/services/authenticated_service.dart';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+class BranchBuild {
+  const BranchBuild({
+    required this.branch,
+    required this.prNumber,
+    required this.prTitle,
+    required this.builtAt,
+    required this.artifactId,
+  });
+
+  factory BranchBuild.fromJson(Map<String, dynamic> json) {
+    return BranchBuild(
+      branch: json['branch'] as String? ?? '',
+      prNumber: json['prNumber'] as int? ?? 0,
+      prTitle: json['prTitle'] as String? ?? '',
+      builtAt: DateTime.tryParse(json['builtAt'] as String? ?? '') ??
+          DateTime.fromMillisecondsSinceEpoch(0),
+      artifactId: (json['artifactId'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  final String branch;
+  final int prNumber;
+  final String prTitle;
+  final DateTime builtAt;
+  final int artifactId;
+}
+
+class BranchService with AuthenticatedService {
+  static final BranchService _instance = BranchService._();
+  BranchService._();
+  static BranchService get instance => _instance;
+
+  static Map<String, String> get _authHeaders => instance.authHeaders;
+
+  static Uri get _apiBaseUri {
+    final configured = AppSettings.instance.activeHost;
+    final base = configured ??
+        const String.fromEnvironment(
+          'API_BASE_URL',
+          defaultValue: 'http://localhost:8080',
+        );
+    final uri = Uri.parse(base);
+    final isLoopback =
+        uri.host == 'localhost' || uri.host == '127.0.0.1' || uri.host == '::1';
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.android &&
+        isLoopback) {
+      return uri.replace(host: '10.0.2.2');
+    }
+    return uri;
+  }
+
+  static Future<bool> isDevModeEnabled() async {
+    final uri = _apiBaseUri.resolve('/api/v1/settings/dev-mode');
+    final response = await http.get(uri, headers: _authHeaders);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      return false;
+    }
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic>) return false;
+    return decoded['enabled'] as bool? ?? false;
+  }
+
+  static Future<List<BranchBuild>> listBranches() async {
+    final uri = _apiBaseUri.resolve('/api/v1/version/branches');
+    final response = await http.get(uri, headers: _authHeaders);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Failed to list branches (${response.statusCode})');
+    }
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List) {
+      throw Exception('Unexpected branches response format');
+    }
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(BranchBuild.fromJson)
+        .toList(growable: false);
+  }
+
+  static Future<void> deployBranch(String branch) async {
+    final uri = _apiBaseUri.resolve('/api/v1/version/update');
+    final body = jsonEncode({'branch': branch});
+    await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json', ..._authHeaders},
+      body: body,
+    );
+  }
+
+  static Future<void> returnToRelease(String targetVersion) async {
+    final uri = _apiBaseUri.resolve('/api/v1/version/update');
+    final body = jsonEncode({'version': targetVersion});
+    await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json', ..._authHeaders},
+      body: body,
+    );
+  }
+
+  static Future<bool> checkServerReady() async {
+    try {
+      final uri = _apiBaseUri.resolve('/api/v1/version');
+      final response = await http
+          .get(uri, headers: _authHeaders)
+          .timeout(const Duration(seconds: 5));
+      return response.statusCode >= 200 && response.statusCode < 300;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static Future<String?> getLatestReleaseVersion() async {
+    final uri = _apiBaseUri.resolve('/api/v1/version/available');
+    final response = await http.get(uri, headers: _authHeaders);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw Exception('Failed to fetch available versions (${response.statusCode})');
+    }
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List || decoded.isEmpty) return null;
+    final first = decoded.first;
+    if (first is! Map<String, dynamic>) return null;
+    return first['version'] as String?;
+  }
+}

--- a/lib/services/branch_service.dart
+++ b/lib/services/branch_service.dart
@@ -18,7 +18,8 @@ class BranchBuild {
       branch: json['branch'] as String? ?? '',
       prNumber: json['prNumber'] as int? ?? 0,
       prTitle: json['prTitle'] as String? ?? '',
-      builtAt: DateTime.tryParse(json['builtAt'] as String? ?? '') ??
+      builtAt:
+          DateTime.tryParse(json['builtAt'] as String? ?? '') ??
           DateTime.fromMillisecondsSinceEpoch(0),
       artifactId: (json['artifactId'] as num?)?.toInt() ?? 0,
     );
@@ -103,7 +104,9 @@ class BranchService with AuthenticatedService {
     final uri = _apiBaseUri.resolve('/api/v1/version/available');
     final response = await http.get(uri, headers: _authHeaders);
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw Exception('Failed to fetch available versions (${response.statusCode})');
+      throw Exception(
+        'Failed to fetch available versions (${response.statusCode})',
+      );
     }
     final decoded = jsonDecode(response.body);
     if (decoded is! List || decoded.isEmpty) return null;

--- a/lib/services/branch_service.dart
+++ b/lib/services/branch_service.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
-import 'package:autobutler/services/app_settings.dart';
 import 'package:autobutler/services/authenticated_service.dart';
-import 'package:flutter/foundation.dart';
+import 'package:autobutler/services/base_service.dart';
 import 'package:http/http.dart' as http;
 
 class BranchBuild {
@@ -39,23 +38,7 @@ class BranchService with AuthenticatedService {
 
   static Map<String, String> get _authHeaders => instance.authHeaders;
 
-  static Uri get _apiBaseUri {
-    final configured = AppSettings.instance.activeHost;
-    final base = configured ??
-        const String.fromEnvironment(
-          'API_BASE_URL',
-          defaultValue: 'http://localhost:8080',
-        );
-    final uri = Uri.parse(base);
-    final isLoopback =
-        uri.host == 'localhost' || uri.host == '127.0.0.1' || uri.host == '::1';
-    if (!kIsWeb &&
-        defaultTargetPlatform == TargetPlatform.android &&
-        isLoopback) {
-      return uri.replace(host: '10.0.2.2');
-    }
-    return uri;
-  }
+  static Uri get _apiBaseUri => ApiBaseUri.apiBaseUri;
 
   static Future<bool> isDevModeEnabled() async {
     final uri = _apiBaseUri.resolve('/api/v1/settings/dev-mode');

--- a/lib/widgets/settings/branch_testing_section.dart
+++ b/lib/widgets/settings/branch_testing_section.dart
@@ -119,7 +119,7 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(
         content: Text('Restarting AutoButler\u2026'),
-        duration: Duration(seconds: 60),
+        duration: Duration(seconds: 120),
       ),
     );
 
@@ -129,7 +129,7 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
 
     await Future<void>.delayed(const Duration(seconds: 3));
 
-    final deadline = DateTime.now().add(const Duration(seconds: 60));
+    final deadline = DateTime.now().add(const Duration(seconds: 120));
     while (DateTime.now().isBefore(deadline)) {
       if (!mounted) return;
       final ready = await BranchService.checkServerReady();
@@ -152,7 +152,7 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).clearSnackBars();
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Server did not respond within 60 seconds')),
+      const SnackBar(content: Text('Server did not respond within 120 seconds')),
     );
     setState(() => _isRestarting = false);
   }

--- a/lib/widgets/settings/branch_testing_section.dart
+++ b/lib/widgets/settings/branch_testing_section.dart
@@ -100,16 +100,18 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
       if (latestVersion == null) {
         if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Could not determine latest release version')),
+          const SnackBar(
+            content: Text('Could not determine latest release version'),
+          ),
         );
         return;
       }
       await _deployAndWait(() => BranchService.returnToRelease(latestVersion));
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed: $e')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed: $e')));
     }
   }
 
@@ -152,7 +154,9 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
     if (!mounted) return;
     ScaffoldMessenger.of(context).clearSnackBars();
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Server did not respond within 120 seconds')),
+      const SnackBar(
+        content: Text('Server did not respond within 120 seconds'),
+      ),
     );
     setState(() => _isRestarting = false);
   }
@@ -187,9 +191,9 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
                       'Current build: ',
                       style: TextStyle(fontWeight: FontWeight.w600),
                     ),
-                    Text(_isOnBranch
-                        ? widget.currentVersion!
-                        : 'Release build'),
+                    Text(
+                      _isOnBranch ? widget.currentVersion! : 'Release build',
+                    ),
                   ],
                 ),
                 if (_isOnBranch) ...[
@@ -232,27 +236,27 @@ class _BranchTestingSectionState extends State<BranchTestingSection> {
             ),
           )
         else if (_branches == null || _branches!.isEmpty)
-          const Card(
-            child: ListTile(title: Text('No branch builds available')),
-          )
+          const Card(child: ListTile(title: Text('No branch builds available')))
         else
-          ...(_branches!.map((build) => Card(
-                child: ListTile(
-                  title: Text(
-                    build.branch,
-                    style: const TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                  subtitle: Text('PR #${build.prNumber} \u2014 ${build.prTitle}'),
-                  trailing: Text(
-                    _formatBuildTime(build.builtAt),
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                    ),
-                  ),
-                  onTap: _isRestarting ? null : () => _confirmDeploy(build),
+          ...(_branches!.map(
+            (build) => Card(
+              child: ListTile(
+                title: Text(
+                  build.branch,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
                 ),
-              ))),
+                subtitle: Text('PR #${build.prNumber} \u2014 ${build.prTitle}'),
+                trailing: Text(
+                  _formatBuildTime(build.builtAt),
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                onTap: _isRestarting ? null : () => _confirmDeploy(build),
+              ),
+            ),
+          )),
         if (_isRestarting)
           const Padding(
             padding: EdgeInsets.all(16),

--- a/lib/widgets/settings/branch_testing_section.dart
+++ b/lib/widgets/settings/branch_testing_section.dart
@@ -1,0 +1,264 @@
+import 'dart:async';
+
+import 'package:autobutler/services/branch_service.dart';
+import 'package:flutter/material.dart';
+
+class BranchTestingSection extends StatefulWidget {
+  const BranchTestingSection({super.key, required this.currentVersion});
+
+  final String? currentVersion;
+
+  @override
+  State<BranchTestingSection> createState() => _BranchTestingSectionState();
+}
+
+class _BranchTestingSectionState extends State<BranchTestingSection> {
+  List<BranchBuild>? _branches;
+  bool _isLoading = true;
+  String? _error;
+  bool _isRestarting = false;
+
+  bool get _isOnBranch {
+    final v = widget.currentVersion;
+    return v != null && v.contains('/');
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBranches();
+  }
+
+  Future<void> _loadBranches() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final branches = await BranchService.listBranches();
+      if (!mounted) return;
+      setState(() {
+        _branches = branches;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _confirmDeploy(BranchBuild build) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Deploy branch?'),
+        content: Text(
+          'This will restart AutoButler and switch to ${build.branch}. '
+          "You'll use a clean database for this branch — your production data is unaffected.",
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Deploy'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    await _deployAndWait(() => BranchService.deployBranch(build.branch));
+  }
+
+  Future<void> _confirmReturnToRelease() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Return to latest release?'),
+        content: const Text('AutoButler will restart.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Return'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    try {
+      final latestVersion = await BranchService.getLatestReleaseVersion();
+      if (latestVersion == null) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not determine latest release version')),
+        );
+        return;
+      }
+      await _deployAndWait(() => BranchService.returnToRelease(latestVersion));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed: $e')),
+      );
+    }
+  }
+
+  Future<void> _deployAndWait(Future<void> Function() action) async {
+    setState(() => _isRestarting = true);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Restarting AutoButler\u2026'),
+        duration: Duration(seconds: 60),
+      ),
+    );
+
+    try {
+      await action();
+    } catch (_) {}
+
+    await Future<void>.delayed(const Duration(seconds: 3));
+
+    final deadline = DateTime.now().add(const Duration(seconds: 60));
+    while (DateTime.now().isBefore(deadline)) {
+      if (!mounted) return;
+      final ready = await BranchService.checkServerReady();
+      if (ready) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).clearSnackBars();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Ready'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+        setState(() => _isRestarting = false);
+        _loadBranches();
+        return;
+      }
+      await Future<void>.delayed(const Duration(seconds: 2));
+    }
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).clearSnackBars();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Server did not respond within 60 seconds')),
+    );
+    setState(() => _isRestarting = false);
+  }
+
+  String _formatBuildTime(DateTime dt) {
+    final diff = DateTime.now().difference(dt);
+    if (diff.inSeconds < 60) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    return '${diff.inDays}d ago';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Branch Testing',
+          style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    const Text(
+                      'Current build: ',
+                      style: TextStyle(fontWeight: FontWeight.w600),
+                    ),
+                    Text(_isOnBranch
+                        ? widget.currentVersion!
+                        : 'Release build'),
+                  ],
+                ),
+                if (_isOnBranch) ...[
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    onPressed: _isRestarting ? null : _confirmReturnToRelease,
+                    icon: const Icon(Icons.undo, size: 18),
+                    label: const Text('Return to release'),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (_isLoading)
+          const Center(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            ),
+          )
+        else if (_error != null)
+          Card(
+            child: ListTile(
+              leading: Icon(
+                Icons.error_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: const Text('Failed to load branches'),
+              subtitle: Text(_error!),
+              trailing: IconButton(
+                icon: const Icon(Icons.refresh),
+                onPressed: _loadBranches,
+              ),
+            ),
+          )
+        else if (_branches == null || _branches!.isEmpty)
+          const Card(
+            child: ListTile(title: Text('No branch builds available')),
+          )
+        else
+          ...(_branches!.map((build) => Card(
+                child: ListTile(
+                  title: Text(
+                    build.branch,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  subtitle: Text('PR #${build.prNumber} \u2014 ${build.prTitle}'),
+                  trailing: Text(
+                    _formatBuildTime(build.builtAt),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                  onTap: _isRestarting ? null : () => _confirmDeploy(build),
+                ),
+              ))),
+        if (_isRestarting)
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Add the Flutter UI for branch testing (Phase 4 of epic #884).

### Go backend
- `GET /api/v1/version/branches` — proxies to the provisioning service to list available PR branch artifacts (requires dev mode)
- `GET /api/v1/settings/dev-mode` — returns whether dev mode is enabled
- New `v1_settings` route package registered in the server router

### Flutter frontend
- `BranchService` — HTTP client for branch listing, deploy, return-to-release, and server readiness polling
- `BranchTestingSection` widget — shows available branch builds, confirmation dialogs for deploy/return, and handles restart polling with a 60-second timeout
- Integrated into the settings page via dev mode check (hidden when dev mode is off)

### Swagger
- Regenerated swagger docs with new endpoints

Closes #887