### PR TITLE
feat: Phase 1 Cirrus thumbnails — cached images with shimmer loading (#913)

### DIFF
--- a/assets/sbom_flutter.json
+++ b/assets/sbom_flutter.json
@@ -25,6 +25,24 @@
       "url": "https://pub.dev"
     },
     {
+      "name": "cached_network_image",
+      "version": "3.4.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "cached_network_image_platform_interface",
+      "version": "4.1.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "cached_network_image_web",
+      "version": "1.3.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
       "name": "characters",
       "version": "1.4.1",
       "source": "hosted",
@@ -121,9 +139,21 @@
       "url": "https://pub.dev"
     },
     {
+      "name": "fixnum",
+      "version": "1.1.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
       "name": "flutter",
       "version": "0.0.0",
       "source": "sdk"
+    },
+    {
+      "name": "flutter_cache_manager",
+      "version": "3.4.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
     },
     {
       "name": "flutter_file_dialog",
@@ -304,6 +334,12 @@
       "url": "https://pub.dev"
     },
     {
+      "name": "octo_image",
+      "version": "2.1.0",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
       "name": "open_filex",
       "version": "4.7.0",
       "source": "hosted",
@@ -388,6 +424,12 @@
       "url": "https://pub.dev"
     },
     {
+      "name": "rxdart",
+      "version": "0.28.0",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
       "name": "shared_preferences",
       "version": "2.5.4",
       "source": "hosted",
@@ -430,6 +472,12 @@
       "url": "https://pub.dev"
     },
     {
+      "name": "shimmer",
+      "version": "3.0.0",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
       "name": "sky_engine",
       "version": "0.0.0",
       "source": "sdk"
@@ -437,6 +485,36 @@
     {
       "name": "source_span",
       "version": "1.10.2",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "sqflite",
+      "version": "2.4.2",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "sqflite_android",
+      "version": "2.4.2+3",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "sqflite_common",
+      "version": "2.5.6",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "sqflite_darwin",
+      "version": "2.4.2",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "sqflite_platform_interface",
+      "version": "2.4.0",
       "source": "hosted",
       "url": "https://pub.dev"
     },
@@ -455,6 +533,12 @@
     {
       "name": "string_scanner",
       "version": "1.4.1",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "synchronized",
+      "version": "3.4.0",
       "source": "hosted",
       "url": "https://pub.dev"
     },
@@ -527,6 +611,12 @@
     {
       "name": "url_launcher_windows",
       "version": "3.1.5",
+      "source": "hosted",
+      "url": "https://pub.dev"
+    },
+    {
+      "name": "uuid",
+      "version": "4.5.3",
       "source": "hosted",
       "url": "https://pub.dev"
     },

--- a/lib/services/cirrus_service.dart
+++ b/lib/services/cirrus_service.dart
@@ -55,7 +55,11 @@ class CirrusService with AuthenticatedService {
   /// Construct a URL for the thumbnail endpoint.
   /// The backend exposes thumbnails at /api/v1/thumbnails/*filePath where filePath is a
   /// path-like segment. Each path segment is percent-encoded to preserve slashes.
-  static Uri constructThumbnailUrl(String filePath, {String? serial}) {
+  static Uri constructThumbnailUrl(
+    String filePath, {
+    String? serial,
+    String? size,
+  }) {
     final trimmed = filePath.trim();
     final normalized = trimmed.startsWith('/') ? trimmed.substring(1) : trimmed;
     final encodedPath = normalized
@@ -69,6 +73,7 @@ class CirrusService with AuthenticatedService {
     final params = <String, String>{};
     final serialValue = serial?.trim() ?? '';
     if (serialValue.isNotEmpty) params['serial'] = serialValue;
+    if (size != null && size.isNotEmpty) params['size'] = size;
     final token = AppSettings.instance.sessionToken;
     if (token != null && token.isNotEmpty) params['token'] = token;
 

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -5,9 +5,11 @@ import 'package:autobutler/utils/file_browser_path_utils.dart';
 import 'package:autobutler/utils/safe_set_state_mixin.dart';
 import 'package:autobutler/widgets/core/autobutler_file_icon.dart';
 import 'package:autobutler/widgets/core/empty_state_widget.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
 
 enum FileMenuAction {
   download,
@@ -237,7 +239,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
       color: Colors.transparent,
       child: ListTile(
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
-        leading: AutobutlerFileIcon(node: item),
+        leading: _buildListLeading(item),
         title: Row(
           children: [
             Expanded(
@@ -458,47 +460,41 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                (() {
-                                  final lower = item.name.toLowerCase();
-                                  final isImage =
-                                      lower.endsWith('.jpg') ||
-                                      lower.endsWith('.jpeg') ||
-                                      lower.endsWith('.png') ||
-                                      lower.endsWith('.gif') ||
-                                      lower.endsWith('.webp');
-                                  if (isImage) {
-                                    final url =
-                                        CirrusService.constructThumbnailUrl(
-                                          item.apiPath,
-                                          serial: item.deviceSerial,
-                                        );
-                                    return SizedBox(
-                                      height: 96,
-                                      width: double.infinity,
-                                      child: Image.network(
-                                        url.toString(),
-                                        fit: BoxFit.cover,
-                                        loadingBuilder:
-                                            (context, child, progress) {
-                                              if (progress == null) {
-                                                return child;
-                                              }
-                                              return Container(
-                                                color: Colors.grey[300],
-                                              );
-                                            },
-                                        errorBuilder: (context, error, stack) =>
-                                            Container(color: Colors.grey[300]),
-                                      ),
-                                    );
-                                  }
-                                  return Center(
+                                if (_isImageFile(item))
+                                  SizedBox(
+                                    height: 96,
+                                    width: double.infinity,
+                                    child: CachedNetworkImage(
+                                      imageUrl:
+                                          CirrusService.constructThumbnailUrl(
+                                            item.apiPath,
+                                            serial: item.deviceSerial,
+                                          ).toString(),
+                                      fit: BoxFit.cover,
+                                      placeholder: (context, url) =>
+                                          Shimmer.fromColors(
+                                            baseColor: Colors.grey[800]!,
+                                            highlightColor: Colors.grey[700]!,
+                                            child: Container(
+                                              color: Colors.grey[800],
+                                            ),
+                                          ),
+                                      errorWidget: (context, url, error) =>
+                                          Center(
+                                            child: AutobutlerFileIcon(
+                                              node: item,
+                                              size: 48,
+                                            ),
+                                          ),
+                                    ),
+                                  )
+                                else
+                                  Center(
                                     child: AutobutlerFileIcon(
                                       node: item,
                                       size: 48,
                                     ),
-                                  );
-                                })(),
+                                  ),
                                 const SizedBox(height: 8),
                                 Flexible(
                                   child: Text(
@@ -638,6 +634,46 @@ class _FileBrowserViewState extends State<FileBrowserView> {
           ],
         );
       },
+    );
+  }
+
+  static bool _isImageFile(CirrusFileNode node) {
+    if (node.isDir) return false;
+    final lower = node.name.toLowerCase();
+    return lower.endsWith('.jpg') ||
+        lower.endsWith('.jpeg') ||
+        lower.endsWith('.png') ||
+        lower.endsWith('.gif') ||
+        lower.endsWith('.webp') ||
+        lower.endsWith('.heic') ||
+        lower.endsWith('.heif');
+  }
+
+  Widget _buildListLeading(CirrusFileNode item) {
+    if (!_isImageFile(item)) {
+      return AutobutlerFileIcon(node: item);
+    }
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: SizedBox(
+        width: 40,
+        height: 40,
+        child: CachedNetworkImage(
+          imageUrl: CirrusService.constructThumbnailUrl(
+            item.apiPath,
+            serial: item.deviceSerial,
+            size: 'sm',
+          ).toString(),
+          fit: BoxFit.cover,
+          placeholder: (context, url) => Shimmer.fromColors(
+            baseColor: Colors.grey[800]!,
+            highlightColor: Colors.grey[700]!,
+            child: Container(color: Colors.grey[800]),
+          ),
+          errorWidget: (context, url, error) => AutobutlerFileIcon(node: item),
+        ),
+      ),
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -33,6 +33,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -161,11 +185,27 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.3.10"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   flutter_file_dialog:
     dependency: "direct main"
     description:
@@ -400,6 +440,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   open_filex:
     dependency: "direct main"
     description:
@@ -512,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -568,6 +624,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shimmer:
+    dependency: "direct main"
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -581,6 +645,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "881e28efdcc9950fd8e9bb42713dcf1103e62a2e7168f23c9338d82db13dec40"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+3"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -605,6 +709,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:
@@ -701,6 +813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   go_router: ^17.1.0
   url_launcher: ^6.3.2
   web_socket_channel: ^3.0.3
+  cached_network_image: ^3.4.1
+  shimmer: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Implements Phase 1 of thumbnail support in the Cirrus file browser.

### Changes

- ****: Added `cached_network_image: ^3.4.1` and `shimmer: ^3.0.0` dependencies
- **`cirrus_service.dart`**: Extended `constructThumbnailUrl` with an optional `size` parameter (backend ignores it for now — Phase 2 will implement server-side sizing)
- **`file_browser_view.dart`**:
  - Replaced `Image.network` in grid view with `CachedNetworkImage` + shimmer placeholder
  - Added list view thumbnails via new `_buildListLeading` helper
  - Extracted `_isImageFile` static helper to deduplicate the extension check (DRY)
  - Added `heic` and `heif` to supported image extensions

### Behavior

- Grid view: images load with a shimmer animation, fall back to file icon on error
- List view: 40×40 rounded thumbnail for image files, file icon for everything else
- Cache handled by `flutter_cache_manager` (via `cached_network_image`) — no re-fetches on scroll

### Phases

- ✅ **Phase 1** (this PR): Client-side caching + shimmer + list view thumbnails
- ⏳ Phase 2: Backend `?size=` param for proper thumbnail sizing
- ⏳ Phase 3+: Video thumbnails, progressive loading, etc.

Closes #913