### PR TITLE
fix: audit and repair light color theme across the app (#929)

### DIFF
--- a/lib/widgets/autobutler_brand_button.dart
+++ b/lib/widgets/autobutler_brand_button.dart
@@ -30,6 +30,7 @@ class AutobutlerBrandButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final radius = BorderRadius.circular(AutobutlerColors.radiusMd);
     return MouseRegion(
       cursor: SystemMouseCursors.click,
@@ -49,24 +50,20 @@ class AutobutlerBrandButton extends StatelessWidget {
                   width: 28,
                   height: 28,
                   decoration: BoxDecoration(
-                    color: AutobutlerColors.primary,
+                    color: colorScheme.primary,
                     borderRadius: radius,
                   ),
                   child: Center(
-                    child: Icon(
-                      icon,
-                      size: 16,
-                      color: AutobutlerColors.primaryForeground,
-                    ),
+                    child: Icon(icon, size: 16, color: colorScheme.onPrimary),
                   ),
                 ),
                 const SizedBox(width: 10),
                 Text(
                   label,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 15,
                     fontWeight: FontWeight.w600,
-                    color: AutobutlerColors.cardForeground,
+                    color: colorScheme.onSurface,
                   ),
                 ),
               ],

--- a/lib/widgets/core/autobutler_storage_bar.dart
+++ b/lib/widgets/core/autobutler_storage_bar.dart
@@ -19,13 +19,14 @@ class AutobutlerStorageBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final clamped = usedFraction.clamp(0.0, 1.0);
     final color = colorForFraction(clamped);
     return Container(
       height: height,
       decoration: BoxDecoration(
-        color: AutobutlerColors.input,
-        border: Border.all(color: AutobutlerColors.border),
+        color: colorScheme.surfaceContainerHighest,
+        border: Border.all(color: colorScheme.outline),
         borderRadius: BorderRadius.circular(AutobutlerColors.radiusMd),
       ),
       clipBehavior: Clip.antiAlias,

--- a/lib/widgets/core/empty_state_widget.dart
+++ b/lib/widgets/core/empty_state_widget.dart
@@ -1,4 +1,3 @@
-import 'package:autobutler/theme/autobutler_colors.dart';
 import 'package:flutter/material.dart';
 
 class EmptyStateWidget extends StatelessWidget {
@@ -17,21 +16,26 @@ class EmptyStateWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Center(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 56, color: AutobutlerColors.mutedForeground),
+            Icon(
+              icon,
+              size: 56,
+              color: colorScheme.onSurface.withValues(alpha: 0.4),
+            ),
             const SizedBox(height: 16),
             Text(
               headline,
               textAlign: TextAlign.center,
-              style: const TextStyle(
+              style: TextStyle(
                 fontSize: 17,
                 fontWeight: FontWeight.w600,
-                color: AutobutlerColors.cardForeground,
+                color: colorScheme.onSurface,
               ),
             ),
             if (subtext != null) ...[
@@ -39,9 +43,9 @@ class EmptyStateWidget extends StatelessWidget {
               Text(
                 subtext!,
                 textAlign: TextAlign.center,
-                style: const TextStyle(
+                style: TextStyle(
                   fontSize: 14,
-                  color: AutobutlerColors.mutedForeground,
+                  color: colorScheme.onSurface.withValues(alpha: 0.5),
                   height: 1.5,
                 ),
               ),

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -1,6 +1,5 @@
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/services/cirrus_service.dart';
-import 'package:autobutler/theme/autobutler_colors.dart';
 import 'package:autobutler/utils/file_browser_path_utils.dart';
 import 'package:autobutler/utils/safe_set_state_mixin.dart';
 import 'package:autobutler/widgets/core/autobutler_file_icon.dart';
@@ -160,8 +159,9 @@ class _FileBrowserViewState extends State<FileBrowserView> {
   // ── Sort header ──────────────────────────────────────────────────────────
 
   Widget _buildSortHeader() {
+    final colorScheme = Theme.of(context).colorScheme;
     return Container(
-      color: AutobutlerColors.sidebar,
+      color: colorScheme.secondary,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         children: [
@@ -179,8 +179,9 @@ class _FileBrowserViewState extends State<FileBrowserView> {
   }
 
   Widget _buildGridSortHeader() {
+    final colorScheme = Theme.of(context).colorScheme;
     return Container(
-      color: AutobutlerColors.sidebar,
+      color: colorScheme.secondary,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Row(
         children: [
@@ -194,6 +195,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
   }
 
   Widget _headerCell(String label, SortColumn column, {int flex = 1}) {
+    final colorScheme = Theme.of(context).colorScheme;
     final isActive = _sortColumn == column;
     return Expanded(
       flex: flex,
@@ -210,8 +212,8 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                   fontSize: 12,
                   fontWeight: FontWeight.w500,
                   color: isActive
-                      ? AutobutlerColors.foreground
-                      : AutobutlerColors.secondaryForeground,
+                      ? colorScheme.onSurface
+                      : colorScheme.onSurfaceVariant,
                 ),
               ),
               if (isActive) ...[
@@ -221,7 +223,7 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                       ? Icons.arrow_upward_rounded
                       : Icons.arrow_downward_rounded,
                   size: 12,
-                  color: AutobutlerColors.foreground,
+                  color: colorScheme.onSurface,
                 ),
               ],
             ],

--- a/lib/widgets/file_browser/file_storage_footer.dart
+++ b/lib/widgets/file_browser/file_storage_footer.dart
@@ -1,5 +1,4 @@
 import 'package:autobutler/services/health_service.dart';
-import 'package:autobutler/theme/autobutler_colors.dart';
 import 'package:autobutler/widgets/core/autobutler_storage_bar.dart';
 import 'package:flutter/material.dart';
 
@@ -52,26 +51,27 @@ class _FileStorageFooterState extends State<FileStorageFooter> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final barColor = AutobutlerStorageBar.colorForFraction(_diskPercent);
     return Container(
-      decoration: const BoxDecoration(
-        color: AutobutlerColors.sidebar,
-        border: Border(top: BorderSide(color: AutobutlerColors.border)),
+      decoration: BoxDecoration(
+        color: colorScheme.secondary,
+        border: Border(top: BorderSide(color: colorScheme.outline)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       child: Row(
         children: [
-          const Icon(
+          Icon(
             Icons.storage_rounded,
             size: 14,
-            color: AutobutlerColors.mutedForeground,
+            color: colorScheme.onSurface.withValues(alpha: 0.4),
           ),
           const SizedBox(width: 8),
           Text(
             _loaded ? _label : 'Storage',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 12,
-              color: AutobutlerColors.mutedForeground,
+              color: colorScheme.onSurface.withValues(alpha: 0.4),
             ),
           ),
           const SizedBox(width: 12),

--- a/lib/widgets/file_browser/file_top_bar.dart
+++ b/lib/widgets/file_browser/file_top_bar.dart
@@ -26,6 +26,9 @@ class FileTopBar extends StatelessWidget {
     required this.onNewFilePressed,
     required this.onOpenDrawer,
     required this.onOpenSettings,
+    this.devices,
+    this.activeDevicePaths,
+    this.onDeviceToggled,
     super.key,
   });
 
@@ -50,13 +53,17 @@ class FileTopBar extends StatelessWidget {
   final VoidCallback onNewFilePressed;
   final VoidCallback onOpenDrawer;
   final VoidCallback onOpenSettings;
+  final List<dynamic>? devices;
+  final List<String>? activeDevicePaths;
+  final ValueChanged<String>? onDeviceToggled;
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Container(
-      decoration: const BoxDecoration(
-        color: AutobutlerColors.sidebar,
-        border: Border(bottom: BorderSide(color: AutobutlerColors.border)),
+      decoration: BoxDecoration(
+        color: colorScheme.secondary,
+        border: Border(bottom: BorderSide(color: colorScheme.outline)),
       ),
       child: SafeArea(
         bottom: false,
@@ -98,12 +105,14 @@ class FileTopBar extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         _iconBtn(
+          context: context,
           icon: Icons.arrow_back_rounded,
           onTap: currentPath.isEmpty ? null : onGoUp,
           tooltip: 'Back',
         ),
         const SizedBox(width: 4),
         _iconBtn(
+          context: context,
           icon: Icons.arrow_upward_rounded,
           onTap: currentPath.isEmpty ? null : onGoUp,
           tooltip: 'Up one level',
@@ -123,12 +132,14 @@ class FileTopBar extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         _iconBtn(
+          context: context,
           icon: Icons.search_rounded,
           onTap: onSearchPressed,
           tooltip: 'Search',
         ),
         const SizedBox(width: 4),
         _iconBtn(
+          context: context,
           icon: Icons.settings_outlined,
           onTap: onOpenSettings,
           tooltip: 'Settings',
@@ -138,11 +149,10 @@ class FileTopBar extends StatelessWidget {
   }
 
   Widget _buildPathRow(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Container(
-      decoration: const BoxDecoration(
-        border: Border(
-          top: BorderSide(color: AutobutlerColors.border, width: 0.5),
-        ),
+      decoration: BoxDecoration(
+        border: Border(top: BorderSide(color: colorScheme.outline, width: 0.5)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: LayoutBuilder(
@@ -161,6 +171,10 @@ class FileTopBar extends StatelessWidget {
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      if (devices != null && devices!.length > 1) ...[
+                        _buildDeviceChips(context),
+                        const SizedBox(width: 8),
+                      ],
                       _buildActions(context),
                       const SizedBox(width: 8),
                       _buildViewChips(context),
@@ -174,6 +188,10 @@ class FileTopBar extends StatelessWidget {
           return Row(
             children: [
               Expanded(child: _buildBreadcrumb(context)),
+              if (devices != null && devices!.length > 1) ...[
+                const SizedBox(width: 12),
+                _buildDeviceChips(context),
+              ],
               const SizedBox(width: 12),
               _buildActions(context),
               const SizedBox(width: 8),
@@ -186,13 +204,14 @@ class FileTopBar extends StatelessWidget {
   }
 
   Widget _buildBreadcrumb(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         decoration: BoxDecoration(
-          color: AutobutlerColors.input,
-          border: Border.all(color: AutobutlerColors.border),
+          color: colorScheme.surfaceContainerHighest,
+          border: Border.all(color: colorScheme.outline),
           borderRadius: BorderRadius.circular(AutobutlerColors.radiusLg),
         ),
         child: Row(
@@ -203,22 +222,22 @@ class FileTopBar extends StatelessWidget {
               child: InkWell(
                 onTap: onGoHome,
                 borderRadius: BorderRadius.circular(4),
-                child: const Padding(
-                  padding: EdgeInsets.all(2),
+                child: Padding(
+                  padding: const EdgeInsets.all(2),
                   child: Icon(
                     Icons.home_rounded,
                     size: 16,
-                    color: AutobutlerColors.secondaryForeground,
+                    color: colorScheme.onSurfaceVariant,
                   ),
                 ),
               ),
             ),
             const SizedBox(width: 6),
-            const Text(
+            Text(
               '/',
               style: TextStyle(
                 fontSize: 13,
-                color: AutobutlerColors.secondaryForeground,
+                color: colorScheme.onSurfaceVariant,
               ),
             ),
             ..._buildCrumbs(context),
@@ -229,6 +248,7 @@ class FileTopBar extends StatelessWidget {
   }
 
   List<Widget> _buildCrumbs(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     if (currentPath.isEmpty) return [];
     final trimmed = currentPath.startsWith('/')
         ? currentPath.substring(1)
@@ -239,12 +259,12 @@ class FileTopBar extends StatelessWidget {
 
     for (var i = 0; i < segments.length; i++) {
       widgets.add(
-        const Padding(
-          padding: EdgeInsets.symmetric(horizontal: 4),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
           child: Icon(
             Icons.chevron_right_rounded,
             size: 14,
-            color: AutobutlerColors.mutedForeground,
+            color: colorScheme.onSurface.withValues(alpha: 0.4),
           ),
         ),
       );
@@ -266,9 +286,7 @@ class FileTopBar extends StatelessWidget {
                 segments[i],
                 style: TextStyle(
                   fontSize: 13,
-                  color: isLast
-                      ? AutobutlerColors.foreground
-                      : AutobutlerColors.primary,
+                  color: isLast ? colorScheme.onSurface : colorScheme.primary,
                 ),
               ),
             ),
@@ -279,11 +297,34 @@ class FileTopBar extends StatelessWidget {
     return widgets;
   }
 
+  Widget _buildDeviceChips(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: devices!.map((device) {
+        final isSelected =
+            activeDevicePaths?.contains(device.devicePath) ?? true;
+        return Padding(
+          padding: const EdgeInsets.only(right: 4),
+          child: _chip(
+            context: context,
+            icon: Icons.devices_rounded,
+            label: device.deviceName ?? device.devicePath,
+            onTap: onDeviceToggled != null
+                ? () => onDeviceToggled!(device.devicePath)
+                : null,
+            active: isSelected,
+          ),
+        );
+      }).toList(),
+    );
+  }
+
   Widget _buildActions(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         _chip(
+          context: context,
           icon: Icons.upload_rounded,
           label: isUploading
               ? (uploadTotal > 0
@@ -294,12 +335,14 @@ class FileTopBar extends StatelessWidget {
         ),
         const SizedBox(width: 6),
         _chip(
+          context: context,
           icon: Icons.create_new_folder_outlined,
           label: 'New folder',
           onTap: isCreatingFolder ? null : onCreateFolderPressed,
         ),
         const SizedBox(width: 6),
         _chip(
+          context: context,
           icon: Icons.edit_document,
           label: 'New file',
           onTap: onNewFilePressed,
@@ -313,6 +356,7 @@ class FileTopBar extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         _segmentedToggle(
+          context: context,
           segments: const [
             (icon: Icons.view_list_rounded, label: 'List'),
             (icon: Icons.grid_view_rounded, label: 'Grid'),
@@ -327,6 +371,7 @@ class FileTopBar extends StatelessWidget {
         ),
         const SizedBox(width: 4),
         _chip(
+          context: context,
           icon: isUnifiedView
               ? Icons.folder_copy_outlined
               : Icons.device_hub_outlined,
@@ -339,15 +384,17 @@ class FileTopBar extends StatelessWidget {
   }
 
   Widget _segmentedToggle({
+    required BuildContext context,
     required List<({IconData icon, String label})> segments,
     required int selectedIndex,
     required ValueChanged<int> onSelected,
   }) {
+    final colorScheme = Theme.of(context).colorScheme;
     final radius = BorderRadius.circular(AutobutlerColors.radiusLg);
     return Material(
-      color: AutobutlerColors.input,
+      color: colorScheme.surfaceContainerHighest,
       shape: RoundedRectangleBorder(
-        side: const BorderSide(color: AutobutlerColors.border),
+        side: BorderSide(color: colorScheme.outline),
         borderRadius: radius,
       ),
       clipBehavior: Clip.antiAlias,
@@ -392,12 +439,10 @@ class FileTopBar extends StatelessWidget {
                   ),
                   decoration: BoxDecoration(
                     color: isActive
-                        ? AutobutlerColors.primary.withValues(alpha: 0.12)
+                        ? colorScheme.primary.withValues(alpha: 0.12)
                         : Colors.transparent,
                     border: i > 0
-                        ? const Border(
-                            left: BorderSide(color: AutobutlerColors.border),
-                          )
+                        ? Border(left: BorderSide(color: colorScheme.outline))
                         : null,
                   ),
                   child: Row(
@@ -407,8 +452,8 @@ class FileTopBar extends StatelessWidget {
                         seg.icon,
                         size: 14,
                         color: isActive
-                            ? AutobutlerColors.primary
-                            : AutobutlerColors.secondaryForeground,
+                            ? colorScheme.primary
+                            : colorScheme.onSurfaceVariant,
                       ),
                       const SizedBox(width: 6),
                       Text(
@@ -416,8 +461,8 @@ class FileTopBar extends StatelessWidget {
                         style: TextStyle(
                           fontSize: 13,
                           color: isActive
-                              ? AutobutlerColors.primary
-                              : AutobutlerColors.secondaryForeground,
+                              ? colorScheme.primary
+                              : colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ],
@@ -432,10 +477,12 @@ class FileTopBar extends StatelessWidget {
   }
 
   Widget _iconBtn({
+    required BuildContext context,
     required IconData icon,
     required VoidCallback? onTap,
     required String tooltip,
   }) {
+    final colorScheme = Theme.of(context).colorScheme;
     final radius = BorderRadius.circular(AutobutlerColors.radiusMd);
     return Tooltip(
       message: tooltip,
@@ -444,9 +491,9 @@ class FileTopBar extends StatelessWidget {
             ? SystemMouseCursors.click
             : SystemMouseCursors.basic,
         child: Material(
-          color: AutobutlerColors.input,
+          color: colorScheme.surfaceContainerHighest,
           shape: RoundedRectangleBorder(
-            side: const BorderSide(color: AutobutlerColors.border),
+            side: BorderSide(color: colorScheme.outline),
             borderRadius: radius,
           ),
           clipBehavior: Clip.antiAlias,
@@ -459,8 +506,8 @@ class FileTopBar extends StatelessWidget {
                 icon,
                 size: 18,
                 color: onTap != null
-                    ? AutobutlerColors.secondaryForeground
-                    : AutobutlerColors.mutedForeground,
+                    ? colorScheme.onSurfaceVariant
+                    : colorScheme.onSurface.withValues(alpha: 0.3),
               ),
             ),
           ),
@@ -470,11 +517,13 @@ class FileTopBar extends StatelessWidget {
   }
 
   Widget _chip({
+    required BuildContext context,
     required IconData icon,
     required String label,
     VoidCallback? onTap,
     bool active = false,
   }) {
+    final colorScheme = Theme.of(context).colorScheme;
     final radius = BorderRadius.circular(AutobutlerColors.radiusLg);
     return MouseRegion(
       cursor: onTap != null
@@ -482,13 +531,13 @@ class FileTopBar extends StatelessWidget {
           : SystemMouseCursors.basic,
       child: Material(
         color: active
-            ? AutobutlerColors.primary.withValues(alpha: 0.12)
-            : AutobutlerColors.input,
+            ? colorScheme.primary.withValues(alpha: 0.12)
+            : colorScheme.surfaceContainerHighest,
         shape: RoundedRectangleBorder(
           side: BorderSide(
             color: active
-                ? AutobutlerColors.primary.withValues(alpha: 0.3)
-                : AutobutlerColors.border,
+                ? colorScheme.primary.withValues(alpha: 0.3)
+                : colorScheme.outline,
           ),
           borderRadius: radius,
         ),
@@ -505,8 +554,8 @@ class FileTopBar extends StatelessWidget {
                   icon,
                   size: 14,
                   color: active
-                      ? AutobutlerColors.primary
-                      : AutobutlerColors.secondaryForeground,
+                      ? colorScheme.primary
+                      : colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(width: 6),
                 Text(
@@ -514,8 +563,8 @@ class FileTopBar extends StatelessWidget {
                   style: TextStyle(
                     fontSize: 13,
                     color: active
-                        ? AutobutlerColors.primary
-                        : AutobutlerColors.secondaryForeground,
+                        ? colorScheme.primary
+                        : colorScheme.onSurfaceVariant,
                   ),
                 ),
               ],

--- a/lib/widgets/file_browser/new_file_dialog.dart
+++ b/lib/widgets/file_browser/new_file_dialog.dart
@@ -90,7 +90,9 @@ class _NewFileDialogState extends State<_NewFileDialog> {
               Text(
                 'File type',
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                  color: AutobutlerColors.mutedForeground,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
                 ),
               ),
               const SizedBox(height: 8),
@@ -111,7 +113,9 @@ class _NewFileDialogState extends State<_NewFileDialog> {
               Text(
                 'Name',
                 style: Theme.of(context).textTheme.labelMedium?.copyWith(
-                  color: AutobutlerColors.mutedForeground,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.5),
                 ),
               ),
               const SizedBox(height: 8),
@@ -166,9 +170,9 @@ class _TypeCard extends StatelessWidget {
         decoration: BoxDecoration(
           color: isSelected
               ? colorScheme.primaryContainer
-              : AutobutlerColors.input,
+              : colorScheme.surfaceContainerHighest,
           border: Border.all(
-            color: isSelected ? colorScheme.primary : AutobutlerColors.border,
+            color: isSelected ? colorScheme.primary : colorScheme.outline,
             width: isSelected ? 2 : 1,
           ),
           borderRadius: BorderRadius.circular(AutobutlerColors.radiusMd),
@@ -181,7 +185,7 @@ class _TypeCard extends StatelessWidget {
               size: 28,
               color: isSelected
                   ? colorScheme.primary
-                  : AutobutlerColors.mutedForeground,
+                  : colorScheme.onSurface.withValues(alpha: 0.5),
             ),
             const SizedBox(height: 6),
             Text(
@@ -189,9 +193,7 @@ class _TypeCard extends StatelessWidget {
               style: TextStyle(
                 fontSize: 12,
                 fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-                color: isSelected
-                    ? colorScheme.primary
-                    : AutobutlerColors.cardForeground,
+                color: isSelected ? colorScheme.primary : colorScheme.onSurface,
               ),
               textAlign: TextAlign.center,
             ),

--- a/lib/widgets/file_browser/recent_files_section.dart
+++ b/lib/widgets/file_browser/recent_files_section.dart
@@ -82,9 +82,10 @@ class _RecentFilesSectionState extends State<RecentFilesSection> {
         final files = snapshot.data!.where((f) => !f.isDir).toList();
         if (files.isEmpty) return const SizedBox.shrink();
 
+        final colorScheme = Theme.of(context).colorScheme;
         return Container(
-          decoration: const BoxDecoration(
-            border: Border(bottom: BorderSide(color: AutobutlerColors.border)),
+          decoration: BoxDecoration(
+            border: Border(bottom: BorderSide(color: colorScheme.outline)),
           ),
           padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
           child: Column(
@@ -93,18 +94,18 @@ class _RecentFilesSectionState extends State<RecentFilesSection> {
             children: [
               Row(
                 children: [
-                  const Icon(
+                  Icon(
                     Icons.schedule_rounded,
                     size: 14,
-                    color: AutobutlerColors.mutedForeground,
+                    color: colorScheme.onSurface.withValues(alpha: 0.4),
                   ),
                   const SizedBox(width: 6),
-                  const Text(
+                  Text(
                     'Recently uploaded',
                     style: TextStyle(
                       fontSize: 12,
                       fontWeight: FontWeight.w500,
-                      color: AutobutlerColors.mutedForeground,
+                      color: colorScheme.onSurface.withValues(alpha: 0.4),
                     ),
                   ),
                 ],
@@ -161,12 +162,13 @@ class _RecentFileChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: Material(
-        color: AutobutlerColors.input,
+        color: colorScheme.surfaceContainerHighest,
         shape: RoundedRectangleBorder(
-          side: const BorderSide(color: AutobutlerColors.border),
+          side: BorderSide(color: colorScheme.outline),
           borderRadius: BorderRadius.circular(AutobutlerColors.radiusMd),
         ),
         clipBehavior: Clip.antiAlias,
@@ -180,7 +182,7 @@ class _RecentFileChip extends StatelessWidget {
                 AutobutlerFileIcon(
                   node: file,
                   size: 20,
-                  color: AutobutlerColors.secondaryForeground,
+                  color: colorScheme.onSurfaceVariant,
                 ),
                 const SizedBox(width: 8),
                 ConstrainedBox(
@@ -193,9 +195,9 @@ class _RecentFileChip extends StatelessWidget {
                         file.name,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 13,
-                          color: AutobutlerColors.cardForeground,
+                          color: colorScheme.onSurface,
                         ),
                       ),
                       if (file.deviceName.isNotEmpty)
@@ -203,9 +205,9 @@ class _RecentFileChip extends StatelessWidget {
                           file.deviceName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 11,
-                            color: AutobutlerColors.mutedForeground,
+                            color: colorScheme.onSurface.withValues(alpha: 0.4),
                           ),
                         ),
                     ],
@@ -220,12 +222,12 @@ class _RecentFileChip extends StatelessWidget {
                     child: InkWell(
                       onTap: onFolderTap,
                       borderRadius: BorderRadius.circular(4),
-                      child: const Padding(
-                        padding: EdgeInsets.all(4),
+                      child: Padding(
+                        padding: const EdgeInsets.all(4),
                         child: Icon(
                           Icons.folder_open_rounded,
                           size: 14,
-                          color: AutobutlerColors.mutedForeground,
+                          color: colorScheme.onSurface.withValues(alpha: 0.4),
                         ),
                       ),
                     ),


### PR DESCRIPTION
## Summary

Full audit of the light color theme. All 8 widgets that were hard-coding `AutobutlerColors` dark-only values have been updated to use `Theme.of(context).colorScheme` equivalents, so both light and dark themes render correctly.

## Changes

| File | What changed |
|---|---|
| `empty_state_widget` | `onSurface` instead of hard-coded foreground colors |
| `autobutler_storage_bar` | `surfaceContainerHighest`/`outline` for track bg/border |
| `autobutler_brand_button` | `colorScheme.primary`/`onPrimary`/`onSurface` |
| `file_storage_footer` | `colorScheme.secondary`/`outline` for footer container |
| `file_top_bar` | Full audit — all helper methods now accept `BuildContext` and read `colorScheme`; `surfaceContainerHighest`, `outline`, `onSurfaceVariant` throughout |
| `file_browser_view` | Sort header bg + header cell text colors |
| `recent_files_section` | Chip bg, borders, text, icon colors |
| `new_file_dialog` | Type card bg/border/icon/text, label colors |

No radius/spacing constants were changed — only color references.

Closes #929