### PR TITLE
AB-961: feat: add make target for drive spoofing on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,40 @@ remote-deploy: build ## Build and deploy to a remote host via scp, then run the 
 	scp $(EXE) $(DEPLOY_HOST):$(DEPLOY_PATH)
 	ssh $(DEPLOY_HOST) "pkill -f '$(DEPLOY_PATH) serve' || true; nohup $(DEPLOY_PATH) serve > ~/autobutler.log 2>&1 &"
 
+.PHONY: drive
+drive: ## Create and mount a new MyDrive DMG (auto-numbered: MyDrive, MyDrive2, MyDrive3, …)
+	@if ! test -d /Volumes/MyDrive; then \
+		N=""; \
+	else \
+		i=2; \
+		while test -d /Volumes/MyDrive$$i; do i=$$((i+1)); done; \
+		N=$$i; \
+	fi; \
+	NAME="MyDrive$$N"; \
+	FILE="$$HOME/Desktop/mydrive$$N.dmg"; \
+	echo "Creating $$FILE (volume: $$NAME)..."; \
+	hdiutil create -size 100m -fs HFS+ -volname "$$NAME" "$$FILE"; \
+	hdiutil attach "$$FILE"
+
+.PHONY: unmount-drive
+unmount-drive: ## Detach the highest-numbered MyDrive volume currently mounted
+	@highest_num=-1; \
+	highest_name=""; \
+	for name in $$(ls /Volumes/ 2>/dev/null | grep -E '^MyDrive[0-9]*$$'); do \
+		num=$$(echo "$$name" | sed 's/MyDrive//'); \
+		if [ -z "$$num" ]; then num=0; fi; \
+		if [ "$$num" -gt "$$highest_num" ]; then \
+			highest_num=$$num; \
+			highest_name=$$name; \
+		fi; \
+	done; \
+	if [ -z "$$highest_name" ]; then \
+		echo "No MyDrive volumes mounted."; \
+		exit 1; \
+	fi; \
+	echo "Detaching /Volumes/$$highest_name..."; \
+	hdiutil detach "/Volumes/$$highest_name"
+
 .PHONY: serve/backend
 serve/backend: generate/backend ## Serve backend
 	$(GO) run $(ENTRYPOINT) serve


### PR DESCRIPTION
---
  Closes #961

  What

  Adds two Makefile targets for spinning up and tearing down virtual HFS+ drives on macOS during local development. Running make drive creates and mounts a 100MB DMG on the Desktop with automatic
  numbering (MyDrive, MyDrive2, MyDrive3, …) so multiple virtual storage devices can be mounted simultaneously to test multi-device file browser behavior. make unmount-drive pops the highest-numbered
  MyDrive volume off the stack, making it easy to cleanly tear down test drives one at a time.

  Changes

  - Added make drive target: creates a 100MB HFS+ DMG at ~/Desktop/mydrive<N>.dmg, auto-incrementing the volume name (MyDrive, MyDrive2, …) based on what is already mounted, then attaches it
  - Added make unmount-drive target: scans /Volumes/ for MyDrive[0-9]* volumes and detaches the one with the highest number, acting as a LIFO stack

  PR Type

  - Bug fix
  - Feature
  - Refactor
  - Docs / content
  - Chore / tooling
  - Tests

  Surface

  - Backend (Go)
  - Frontend (Flutter)
  - API / swagger
  - CI / workflows
  - Docs / content only

  Testing

  - Local testing recommended (UI changes, routing, behavior changes)
  - Local testing not needed (logic-only, docs, trivial change)
  - Includes new automated tests
  - Manually tested by author

  Bot Review Guidance

  macOS only — hdiutil is not available on Linux. These targets are purely for local dev convenience and are not called from CI.

  Notes

  Run make drive 3–4 times to mount multiple virtual devices, then use make unmount-drive repeatedly to tear them down in reverse order. DMG files persist on the Desktop between sessions; delete them
  manually when no longer needed.