### PR TITLE
fix: auto-update toggle shows incorrect state when server is unreachable (#956)

### DIFF
--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -37,6 +37,8 @@ class _SettingsPageState extends State<SettingsPage> {
   String? _versionLoadError;
 
   bool _autoUpdate = false;
+  bool _autoUpdateLoadFailed = false;
+  bool _isLoadingAutoUpdate = false;
 
   // SBOM state
   GoSbom? _goSbom;
@@ -242,14 +244,24 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _loadSettings() async {
     if (AppSettings.instance.activeHost == null) return;
+    setState(() {
+      _isLoadingAutoUpdate = true;
+    });
     try {
       final autoUpdate = await SettingsService.getAutoUpdate();
       if (!mounted) return;
       setState(() {
         _autoUpdate = autoUpdate;
+        _autoUpdateLoadFailed = false;
+        _isLoadingAutoUpdate = false;
       });
     } catch (e) {
       debugPrint('[settings_page.dart] Error loading settings: $e');
+      if (!mounted) return;
+      setState(() {
+        _autoUpdateLoadFailed = true;
+        _isLoadingAutoUpdate = false;
+      });
     }
   }
 
@@ -580,33 +592,54 @@ class _SettingsPageState extends State<SettingsPage> {
           const SizedBox(height: 16),
           if (AppSettings.instance.activeHost != null)
             Card(
-              child: SwitchListTile(
-                title: const Text('Automatic updates'),
-                subtitle: const Text(
-                  'AutoButler will check for and install updates daily',
-                ),
-                value: _autoUpdate,
-                onChanged: (newValue) async {
-                  setState(() {
-                    _autoUpdate = newValue;
-                  });
-                  final messenger = ScaffoldMessenger.of(context);
-                  try {
-                    await SettingsService.setAutoUpdate(newValue);
-                  } catch (e) {
-                    debugPrint(
-                      '[settings_page.dart] Error saving auto-update: $e',
-                    );
-                    if (!mounted) return;
-                    setState(() {
-                      _autoUpdate = !newValue;
-                    });
-                    messenger.showSnackBar(
-                      SnackBar(content: Text('Failed to save setting: $e')),
-                    );
-                  }
-                },
-              ),
+              child: _isLoadingAutoUpdate
+                  ? const ListTile(
+                      title: Text('Automatic updates'),
+                      subtitle: Text(
+                        'AutoButler will check for and install updates daily',
+                      ),
+                      trailing: SizedBox(
+                        width: 24,
+                        height: 24,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    )
+                  : SwitchListTile(
+                      title: const Text('Automatic updates'),
+                      subtitle: _autoUpdateLoadFailed
+                          ? const Text(
+                              'Could not load setting — server may be unreachable',
+                              style: TextStyle(color: Colors.red),
+                            )
+                          : const Text(
+                              'AutoButler will check for and install updates daily',
+                            ),
+                      value: _autoUpdate,
+                      onChanged: _autoUpdateLoadFailed
+                          ? null
+                          : (newValue) async {
+                              setState(() {
+                                _autoUpdate = newValue;
+                              });
+                              final messenger = ScaffoldMessenger.of(context);
+                              try {
+                                await SettingsService.setAutoUpdate(newValue);
+                              } catch (e) {
+                                debugPrint(
+                                  '[settings_page.dart] Error saving auto-update: $e',
+                                );
+                                if (!mounted) return;
+                                setState(() {
+                                  _autoUpdate = !newValue;
+                                });
+                                messenger.showSnackBar(
+                                  SnackBar(
+                                    content: Text('Failed to save setting: $e'),
+                                  ),
+                                );
+                              }
+                            },
+                    ),
             ),
           const SizedBox(height: 24),
           const Text(


### PR DESCRIPTION
Closes #956

## What

When \`_loadSettings\` failed (e.g. server unreachable or returning a non-2xx response), the auto-update toggle silently defaulted to \`false\` with no indication that the read failed. This meant the UI could show the opposite of the actual backend state. This PR adds proper loading and error states so the user is never shown a potentially incorrect value without context.

## Changes

- Added \`_isLoadingAutoUpdate\` bool — shows a \`CircularProgressIndicator\` in the toggle row while the settings fetch is in flight
- Added \`_autoUpdateLoadFailed\` bool — set to \`true\` in the \`catch\` block of \`_loadSettings\` instead of silently ignoring the error
- Toggle is disabled (\`onChanged: null\`) when \`_autoUpdateLoadFailed\` is true, preventing the user from interacting with a potentially stale value
- Red subtitle "Could not load setting — server may be unreachable" is shown when load fails
- Both flags reset correctly on success so a retry (e.g. navigating away and back) can recover

## PR Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / content
- [ ] Chore / tooling
- [ ] Tests

## Surface

- [ ] Backend (Go)
- [x] Frontend (Flutter)
- [ ] API / swagger
- [ ] CI / workflows
- [ ] Docs / content only

## Testing

- [x] Local testing recommended (UI changes, routing, behavior changes)
- [ ] Local testing not needed (logic-only, docs, trivial change)
- [ ] Includes new automated tests
- [x] Manually tested by author

## Bot Review Guidance

Focus on \`_loadSettings\` in \`lib/pages/settings_page.dart\` and the auto-update \`Card\` widget (~line 593). Verify the three UI states (loading, error, success) are all reachable and that the error state correctly disables interaction.

## Notes

The toggle value (\`_autoUpdate\`) stays \`false\` when load fails, but since \`onChanged\` is \`null\` the user cannot act on it. If a retry mechanism is needed in the future (e.g. a refresh button on the error subtitle), that can be a follow-up.