### PR TITLE
feat: photo selection mode and add-to-album flows (#971)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2216,10 +2216,6 @@ const docTemplate = `{
         },
         "v1_albums.addPhotoRequest": {
             "type": "object",
-            "required": [
-                "deviceSerial",
-                "relPath"
-            ],
             "properties": {
                 "deviceSerial": {
                     "type": "string"

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2205,10 +2205,6 @@
         },
         "v1_albums.addPhotoRequest": {
             "type": "object",
-            "required": [
-                "deviceSerial",
-                "relPath"
-            ],
             "properties": {
                 "deviceSerial": {
                     "type": "string"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -85,9 +85,6 @@ definitions:
         type: string
       relPath:
         type: string
-    required:
-    - deviceSerial
-    - relPath
     type: object
   v1_albums.createAlbumRequest:
     properties:

--- a/internal/server/api/v1/albums/album_items.go
+++ b/internal/server/api/v1/albums/album_items.go
@@ -81,6 +81,9 @@ func addPhotoToAlbum(c *gin.Context) *serverutil.Response {
 	if err := c.ShouldBindJSON(&req); err != nil {
 		return serverutil.BadRequest(errors.New("invalid request body"))
 	}
+	if req.DeviceSerial == "" {
+		return serverutil.BadRequest(errors.New("deviceSerial is required"))
+	}
 	if req.RelPath == "" {
 		return serverutil.BadRequest(errors.New("relPath is required"))
 	}
@@ -133,6 +136,9 @@ func removePhotoFromAlbum(c *gin.Context) *serverutil.Response {
 	var req addPhotoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		return serverutil.BadRequest(errors.New("invalid request body"))
+	}
+	if req.DeviceSerial == "" {
+		return serverutil.BadRequest(errors.New("deviceSerial is required"))
 	}
 	if req.RelPath == "" {
 		return serverutil.BadRequest(errors.New("relPath is required"))

--- a/internal/server/api/v1/albums/album_items.go
+++ b/internal/server/api/v1/albums/album_items.go
@@ -55,8 +55,8 @@ func listAlbumItems(c *gin.Context) *serverutil.Response {
 }
 
 type addPhotoRequest struct {
-	DeviceSerial string `json:"deviceSerial" binding:"required"`
-	RelPath      string `json:"relPath" binding:"required"`
+	DeviceSerial string `json:"deviceSerial"`
+	RelPath      string `json:"relPath"`
 }
 
 // addPhotoToAlbum godoc
@@ -79,7 +79,10 @@ func addPhotoToAlbum(c *gin.Context) *serverutil.Response {
 
 	var req addPhotoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		return serverutil.BadRequest(errors.New("deviceSerial and relPath are required"))
+		return serverutil.BadRequest(errors.New("invalid request body"))
+	}
+	if req.RelPath == "" {
+		return serverutil.BadRequest(errors.New("relPath is required"))
 	}
 
 	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")
@@ -129,7 +132,10 @@ func removePhotoFromAlbum(c *gin.Context) *serverutil.Response {
 
 	var req addPhotoRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		return serverutil.BadRequest(errors.New("deviceSerial and relPath are required"))
+		return serverutil.BadRequest(errors.New("invalid request body"))
+	}
+	if req.RelPath == "" {
+		return serverutil.BadRequest(errors.New("relPath is required"))
 	}
 
 	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")

--- a/lib/pages/album_page.dart
+++ b/lib/pages/album_page.dart
@@ -1,5 +1,6 @@
 import 'package:autobutler/models/photo_album.dart';
 import 'package:autobutler/pages/image_viewer_page.dart';
+import 'package:autobutler/pages/photos_page.dart';
 import 'package:autobutler/services/album_service.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/theme/autobutler_colors.dart';
@@ -49,6 +50,16 @@ class _AlbumPageState extends State<AlbumPage> {
     }
   }
 
+  Future<void> _openAddPhotosMode() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => PhotosPage(addingToAlbum: widget.album),
+      ),
+    );
+    // Reload after returning in case photos were added
+    await _load();
+  }
+
   Future<void> _removeItem(PhotoAlbumItem item) async {
     final confirmed = await showDialog<bool>(
       context: context,
@@ -92,6 +103,11 @@ class _AlbumPageState extends State<AlbumPage> {
       appBar: AppBar(
         title: Text(widget.album.name),
         actions: [
+          TextButton.icon(
+            onPressed: _openAddPhotosMode,
+            icon: const Icon(Icons.add_rounded, size: 18),
+            label: const Text('Add Photos'),
+          ),
           IconButton(
             icon: const Icon(Icons.refresh_rounded),
             tooltip: 'Refresh',

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -814,12 +814,10 @@ class _PhotosPageState extends State<PhotosPage>
   }
 
   Future<void> _confirmAddToAlbum() async {
-    // Flow 2: user tapped Done while in adding-to-album mode
-    // We need the current photo list — pull from state
-    final photos = _selectedCategory == PhotoCategory.mobile
-        ? _mobilePhotos
-        : _cirrusPhotos;
-    await _addSelectedToAlbum(_addingToAlbum!, photos);
+    // Flow 2: user tapped Done while in adding-to-album mode.
+    // Only Cirrus photos can be added to albums, so search _cirrusPhotos
+    // regardless of which tab is currently active.
+    await _addSelectedToAlbum(_addingToAlbum!, _cirrusPhotos);
   }
 
   Future<void> _addSelectedToAlbum(
@@ -920,7 +918,11 @@ class _PhotosPageState extends State<PhotosPage>
                     child: Text('Done (${_selectedKeys.length})'),
                   ),
                 TextButton(
-                  onPressed: _exitSelectionMode,
+                  onPressed: () {
+                    final wasAdding = _addingToAlbum != null;
+                    _exitSelectionMode();
+                    if (wasAdding) Navigator.of(context).pop();
+                  },
                   child: const Text('Cancel'),
                 ),
               ],

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -892,268 +892,270 @@ class _PhotosPageState extends State<PhotosPage>
       child: Focus(
         autofocus: true,
         child: Scaffold(
-      appBar: _selectionMode
-          ? AppBar(
-              backgroundColor: Theme.of(context).colorScheme.secondary,
-              automaticallyImplyLeading: false,
-              title: _addingToAlbum != null
-                  ? Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(
-                          'Adding to ${_addingToAlbum!.name}',
-                          style: TextStyle(
-                            fontSize: 14,
-                            color: Theme.of(context).colorScheme.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                        if (_selectedKeys.isNotEmpty)
-                          Text(
-                            '${_selectedKeys.length} selected',
-                            style: TextStyle(
-                              fontSize: 11,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface.withValues(alpha: 0.5),
-                            ),
-                          ),
-                      ],
-                    )
-                  : Text('${_selectedKeys.length} selected'),
-              actions: [
-                if (_addingToAlbum != null)
-                  TextButton(
-                    onPressed: _selectedKeys.isNotEmpty
-                        ? _confirmAddToAlbum
-                        : null,
-                    child: Text('Done (${_selectedKeys.length})'),
-                  ),
-                TextButton(
-                  onPressed: () {
-                    final wasAdding = _addingToAlbum != null;
-                    _exitSelectionMode();
-                    if (wasAdding) Navigator.of(context).pop();
-                  },
-                  child: const Text('Cancel'),
-                ),
-              ],
-            )
-          : AutobutlerAppBar(
-              label: 'Photos',
-              icon: Icons.photo_library_outlined,
-              actions: [
-                TextButton(
-                  onPressed: _enterSelectionMode,
-                  child: const Text('Select'),
-                ),
-                RefreshIconButton(
-                  isRefreshing: isRefreshing,
-                  onPressed: manualRefresh,
-                  tooltip: 'Reload photos',
-                ),
-              ],
-            ),
-      drawer: AutobutlerDrawer(
-        activeSection: AutobutlerDrawerSection.photos,
-        onTapCirrus: () {
-          context.go(AppRoutes.cirrus);
-        },
-        onTapPhotos: () {
-          Navigator.of(context).pop();
-        },
-        onTapDevices: () {
-          context.go(AppRoutes.devices);
-        },
-        onTapHealth: () {
-          context.go(AppRoutes.health);
-        },
-        onTapSettings: () {
-          context.go(AppRoutes.settings);
-        },
-      ),
-      body: FutureBuilder<List<PhotoItem>>(
-        future: _photosFuture,
-        builder: (context, snapshot) {
-          final photos = snapshot.data ?? const <PhotoItem>[];
-
-          return LayoutBuilder(
-            builder: (context, constraints) {
-              final compact = constraints.maxWidth < 900;
-              final contentWidth = compact
-                  ? constraints.maxWidth
-                  : (constraints.maxWidth - 281)
-                        .clamp(1.0, double.infinity)
-                        .toDouble();
-              final crossAxisCount = _effectiveCrossAxisCount(contentWidth);
-
-              final sidebar = _buildSidebar(
-                context,
-                contentWidth,
-                _cirrusPhotos.length,
-                _mobilePhotos.length,
-                compact: compact,
-              );
-
-              // Desktop: sidebar + grid side-by-side (unchanged behavior)
-              if (!compact) {
-                Widget buildDesktop(Widget content) => Row(
-                  children: [
-                    sidebar,
-                    const VerticalDivider(width: 1),
-                    Expanded(child: content),
-                  ],
-                );
-                if (snapshot.connectionState == ConnectionState.waiting &&
-                    photos.isEmpty) {
-                  return buildDesktop(
-                    const Center(child: CircularProgressIndicator()),
-                  );
-                }
-                if (snapshot.hasError) {
-                  return buildDesktop(
-                    const Center(child: Text('Failed to load photos')),
-                  );
-                }
-                return buildDesktop(_buildPhotoGrid(photos, crossAxisCount));
-              }
-
-              // Mobile: nav panel lives *above* the photo grid in the scroll
-              // stack. On mount we jump to navHeight so only the grid is
-              // visible. Scroll up to reveal the nav.
-              if (snapshot.connectionState == ConnectionState.waiting &&
-                  photos.isEmpty) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              if (snapshot.hasError) {
-                return const Center(child: Text('Failed to load photos'));
-              }
-
-              final showLoadingIndicator =
-                  _hasMoreCirrus &&
-                  (_selectedCategory == PhotoCategory.cirrus ||
-                      _selectedCategory == PhotoCategory.all);
-              final itemCount = photos.length + (showLoadingIndicator ? 1 : 0);
-
-              return Stack(
-                children: [
-                  RefreshIndicator(
-                    onRefresh: manualRefresh,
-                    child: CustomScrollView(
-                      controller: _scrollController,
-                      physics: const AlwaysScrollableScrollPhysics(),
-                      slivers: [
-                        // Nav panel — hidden above viewport on load
-                        SliverToBoxAdapter(
-                          child: Container(
-                            key: _navPanelKey,
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                sidebar,
-                                Divider(
-                                  height: 1,
-                                  color: Theme.of(context).colorScheme.outline,
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                        // Photo grid
-                        photos.isEmpty
-                            ? const SliverFillRemaining(
-                                child: EmptyStateWidget(
-                                  icon: Icons.photo_library_outlined,
-                                  headline: 'No photos yet',
-                                  subtext:
-                                      'Photos you upload to AutoButler will appear here.',
-                                ),
-                              )
-                            : SliverGrid(
-                                delegate: SliverChildBuilderDelegate((
-                                  context,
-                                  idx,
-                                ) {
-                                  if (idx >= photos.length) {
-                                    return const Center(
-                                      child: Padding(
-                                        padding: EdgeInsets.all(16),
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2,
-                                        ),
-                                      ),
-                                    );
-                                  }
-                                  return _buildPhotoTile(
-                                    context,
-                                    photos,
-                                    idx,
-                                    crossAxisCount,
-                                  );
-                                }, childCount: itemCount),
-                                gridDelegate:
-                                    SliverGridDelegateWithFixedCrossAxisCount(
-                                      crossAxisCount: crossAxisCount,
-                                      crossAxisSpacing: 2,
-                                      mainAxisSpacing: 2,
-                                    ),
+          appBar: _selectionMode
+              ? AppBar(
+                  backgroundColor: Theme.of(context).colorScheme.secondary,
+                  automaticallyImplyLeading: false,
+                  title: _addingToAlbum != null
+                      ? Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'Adding to ${_addingToAlbum!.name}',
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Theme.of(context).colorScheme.primary,
+                                fontWeight: FontWeight.w600,
                               ),
-                      ],
-                    ),
-                  ),
-                  // Selection action bar — shown at bottom when in selection mode
-                  if (_selectionMode && _addingToAlbum == null)
-                    Positioned(
-                      bottom: 0,
-                      left: 0,
-                      right: 0,
-                      child: PhotoSelectionBar(
-                        selectedCount: _selectedKeys.length,
-                        onAddToAlbum: () => _handleAddToAlbum(photos),
-                        onCancel: _exitSelectionMode,
-                      ),
-                    ),
-                  // Scroll-up hint — subtle chevron at top, fades when user scrolls
-                  if (_showScrollHint)
-                    Positioned(
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      child: IgnorePointer(
-                        child: Container(
-                          height: 32,
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Theme.of(
-                                  context,
-                                ).colorScheme.surface.withValues(alpha: 0.7),
-                                Colors.transparent,
-                              ],
                             ),
+                            if (_selectedKeys.isNotEmpty)
+                              Text(
+                                '${_selectedKeys.length} selected',
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  color: Theme.of(context).colorScheme.onSurface
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                          ],
+                        )
+                      : Text('${_selectedKeys.length} selected'),
+                  actions: [
+                    if (_addingToAlbum != null)
+                      TextButton(
+                        onPressed: _selectedKeys.isNotEmpty
+                            ? _confirmAddToAlbum
+                            : null,
+                        child: Text('Done (${_selectedKeys.length})'),
+                      ),
+                    TextButton(
+                      onPressed: () {
+                        final wasAdding = _addingToAlbum != null;
+                        _exitSelectionMode();
+                        if (wasAdding) Navigator.of(context).pop();
+                      },
+                      child: const Text('Cancel'),
+                    ),
+                  ],
+                )
+              : AutobutlerAppBar(
+                  label: 'Photos',
+                  icon: Icons.photo_library_outlined,
+                  actions: [
+                    TextButton(
+                      onPressed: _enterSelectionMode,
+                      child: const Text('Select'),
+                    ),
+                    RefreshIconButton(
+                      isRefreshing: isRefreshing,
+                      onPressed: manualRefresh,
+                      tooltip: 'Reload photos',
+                    ),
+                  ],
+                ),
+          drawer: AutobutlerDrawer(
+            activeSection: AutobutlerDrawerSection.photos,
+            onTapCirrus: () {
+              context.go(AppRoutes.cirrus);
+            },
+            onTapPhotos: () {
+              Navigator.of(context).pop();
+            },
+            onTapDevices: () {
+              context.go(AppRoutes.devices);
+            },
+            onTapHealth: () {
+              context.go(AppRoutes.health);
+            },
+            onTapSettings: () {
+              context.go(AppRoutes.settings);
+            },
+          ),
+          body: FutureBuilder<List<PhotoItem>>(
+            future: _photosFuture,
+            builder: (context, snapshot) {
+              final photos = snapshot.data ?? const <PhotoItem>[];
+
+              return LayoutBuilder(
+                builder: (context, constraints) {
+                  final compact = constraints.maxWidth < 900;
+                  final contentWidth = compact
+                      ? constraints.maxWidth
+                      : (constraints.maxWidth - 281)
+                            .clamp(1.0, double.infinity)
+                            .toDouble();
+                  final crossAxisCount = _effectiveCrossAxisCount(contentWidth);
+
+                  final sidebar = _buildSidebar(
+                    context,
+                    contentWidth,
+                    _cirrusPhotos.length,
+                    _mobilePhotos.length,
+                    compact: compact,
+                  );
+
+                  // Desktop: sidebar + grid side-by-side (unchanged behavior)
+                  if (!compact) {
+                    Widget buildDesktop(Widget content) => Row(
+                      children: [
+                        sidebar,
+                        const VerticalDivider(width: 1),
+                        Expanded(child: content),
+                      ],
+                    );
+                    if (snapshot.connectionState == ConnectionState.waiting &&
+                        photos.isEmpty) {
+                      return buildDesktop(
+                        const Center(child: CircularProgressIndicator()),
+                      );
+                    }
+                    if (snapshot.hasError) {
+                      return buildDesktop(
+                        const Center(child: Text('Failed to load photos')),
+                      );
+                    }
+                    return buildDesktop(
+                      _buildPhotoGrid(photos, crossAxisCount),
+                    );
+                  }
+
+                  // Mobile: nav panel lives *above* the photo grid in the scroll
+                  // stack. On mount we jump to navHeight so only the grid is
+                  // visible. Scroll up to reveal the nav.
+                  if (snapshot.connectionState == ConnectionState.waiting &&
+                      photos.isEmpty) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
+                  if (snapshot.hasError) {
+                    return const Center(child: Text('Failed to load photos'));
+                  }
+
+                  final showLoadingIndicator =
+                      _hasMoreCirrus &&
+                      (_selectedCategory == PhotoCategory.cirrus ||
+                          _selectedCategory == PhotoCategory.all);
+                  final itemCount =
+                      photos.length + (showLoadingIndicator ? 1 : 0);
+
+                  return Stack(
+                    children: [
+                      RefreshIndicator(
+                        onRefresh: manualRefresh,
+                        child: CustomScrollView(
+                          controller: _scrollController,
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          slivers: [
+                            // Nav panel — hidden above viewport on load
+                            SliverToBoxAdapter(
+                              child: Container(
+                                key: _navPanelKey,
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    sidebar,
+                                    Divider(
+                                      height: 1,
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.outline,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            // Photo grid
+                            photos.isEmpty
+                                ? const SliverFillRemaining(
+                                    child: EmptyStateWidget(
+                                      icon: Icons.photo_library_outlined,
+                                      headline: 'No photos yet',
+                                      subtext:
+                                          'Photos you upload to AutoButler will appear here.',
+                                    ),
+                                  )
+                                : SliverGrid(
+                                    delegate: SliverChildBuilderDelegate((
+                                      context,
+                                      idx,
+                                    ) {
+                                      if (idx >= photos.length) {
+                                        return const Center(
+                                          child: Padding(
+                                            padding: EdgeInsets.all(16),
+                                            child: CircularProgressIndicator(
+                                              strokeWidth: 2,
+                                            ),
+                                          ),
+                                        );
+                                      }
+                                      return _buildPhotoTile(
+                                        context,
+                                        photos,
+                                        idx,
+                                        crossAxisCount,
+                                      );
+                                    }, childCount: itemCount),
+                                    gridDelegate:
+                                        SliverGridDelegateWithFixedCrossAxisCount(
+                                          crossAxisCount: crossAxisCount,
+                                          crossAxisSpacing: 2,
+                                          mainAxisSpacing: 2,
+                                        ),
+                                  ),
+                          ],
+                        ),
+                      ),
+                      // Selection action bar — shown at bottom when in selection mode
+                      if (_selectionMode && _addingToAlbum == null)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: PhotoSelectionBar(
+                            selectedCount: _selectedKeys.length,
+                            onAddToAlbum: () => _handleAddToAlbum(photos),
+                            onCancel: _exitSelectionMode,
                           ),
-                          child: Center(
-                            child: Icon(
-                              Icons.keyboard_arrow_up_rounded,
-                              size: 20,
-                              color: Theme.of(
-                                context,
-                              ).colorScheme.onSurface.withValues(alpha: 0.4),
+                        ),
+                      // Scroll-up hint — subtle chevron at top, fades when user scrolls
+                      if (_showScrollHint)
+                        Positioned(
+                          top: 0,
+                          left: 0,
+                          right: 0,
+                          child: IgnorePointer(
+                            child: Container(
+                              height: 32,
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  colors: [
+                                    Theme.of(context).colorScheme.surface
+                                        .withValues(alpha: 0.7),
+                                    Colors.transparent,
+                                  ],
+                                ),
+                              ),
+                              child: Center(
+                                child: Icon(
+                                  Icons.keyboard_arrow_up_rounded,
+                                  size: 20,
+                                  color: Theme.of(context).colorScheme.onSurface
+                                      .withValues(alpha: 0.4),
+                                ),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ),
-                ],
+                    ],
+                  );
+                },
               );
             },
-          );
-        },
-      ),
-      ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -1154,6 +1154,7 @@ class _PhotosPageState extends State<PhotosPage>
         },
       ),
       ),
+      ),
     );
   }
 }

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -13,6 +13,7 @@ import 'package:autobutler/services/album_service.dart';
 import 'package:autobutler/widgets/photos/album_sidebar.dart';
 import 'package:autobutler/widgets/photos/photo_selection_bar.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:autobutler/router.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -755,7 +756,7 @@ class _PhotosPageState extends State<PhotosPage>
             )
           : GridView.builder(
               controller: _scrollController,
-              padding: const EdgeInsets.all(2),
+              padding: EdgeInsets.fromLTRB(2, 2, 2, _selectionMode ? 84 : 2),
               gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: crossAxisCount,
                 crossAxisSpacing: 2,
@@ -878,7 +879,19 @@ class _PhotosPageState extends State<PhotosPage>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.escape): () {
+          if (_selectionMode) {
+            final wasAdding = _addingToAlbum != null;
+            _exitSelectionMode();
+            if (wasAdding) Navigator.of(context).pop();
+          }
+        },
+      },
+      child: Focus(
+        autofocus: true,
+        child: Scaffold(
       appBar: _selectionMode
           ? AppBar(
               backgroundColor: Theme.of(context).colorScheme.secondary,
@@ -1139,6 +1152,7 @@ class _PhotosPageState extends State<PhotosPage>
             },
           );
         },
+      ),
       ),
     );
   }

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -831,8 +831,13 @@ class _PhotosPageState extends State<PhotosPage>
         .toList();
 
     int added = 0;
+    int skipped = 0;
+    int failed = 0;
     for (final item in selected) {
-      if (!item.isCirrus) continue;
+      if (!item.isCirrus) {
+        skipped++;
+        continue;
+      }
       final c = item.cirrus!;
       try {
         await AlbumService.addPhotoToAlbum(
@@ -841,7 +846,9 @@ class _PhotosPageState extends State<PhotosPage>
           relPath: c.dirPath,
         );
         added++;
-      } catch (_) {}
+      } catch (_) {
+        failed++;
+      }
     }
 
     if (!mounted) return;
@@ -849,19 +856,25 @@ class _PhotosPageState extends State<PhotosPage>
     final wasAddingMode = _addingToAlbum != null;
     _exitSelectionMode();
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          added == 0
-              ? 'No photos added (only Cirrus photos can be added to albums)'
-              : '$added ${added == 1 ? 'photo' : 'photos'} added to "${album.name}"',
-        ),
-      ),
-    );
+    String message;
+    if (added == 0 && skipped > 0) {
+      message = 'No photos added — device photos cannot be added to albums yet';
+    } else if (added > 0) {
+      message =
+          '$added ${added == 1 ? 'photo' : 'photos'} added to "${album.name}"';
+      if (failed > 0) message += ' ($failed failed)';
+    } else {
+      message = 'Failed to add photos to "${album.name}"';
+    }
 
-    if (wasAddingMode) {
-      // Navigate back to the album page
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
+
+    if (wasAddingMode && added > 0) {
       Navigator.of(context).pop();
+    } else if (wasAddingMode && added == 0) {
+      // Stay in adding mode so user can try again or pick different photos
     }
   }
 

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -7,8 +7,11 @@ import 'package:autobutler/services/app_settings.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
+import 'package:autobutler/models/photo_album.dart';
 import 'package:autobutler/pages/album_page.dart';
+import 'package:autobutler/services/album_service.dart';
 import 'package:autobutler/widgets/photos/album_sidebar.dart';
+import 'package:autobutler/widgets/photos/photo_selection_bar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:autobutler/router.dart';
 import 'package:flutter/material.dart';
@@ -16,7 +19,11 @@ import 'package:go_router/go_router.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 class PhotosPage extends StatefulWidget {
-  const PhotosPage({super.key});
+  const PhotosPage({this.addingToAlbum, super.key});
+
+  /// When set, the page opens in "adding to album" mode — selection mode is
+  /// immediately active and the header shows the album name.
+  final PhotoAlbum? addingToAlbum;
 
   @override
   State<PhotosPage> createState() => _PhotosPageState();
@@ -33,6 +40,14 @@ class PhotoItem {
 
   factory PhotoItem.fromCirrus(CirrusFileNode c) => PhotoItem._(cirrus: c);
   factory PhotoItem.fromAsset(AssetEntity a) => PhotoItem._(asset: a);
+
+  /// A stable key for this item suitable for use in a selection set.
+  String get selectionKey {
+    if (isCirrus) {
+      return '${cirrus!.deviceSerial}:${cirrus!.dirPath}';
+    }
+    return 'asset:${asset!.id}';
+  }
 }
 
 class _PhotosPageState extends State<PhotosPage>
@@ -74,6 +89,12 @@ class _PhotosPageState extends State<PhotosPage>
   bool _navScrollInitialized = false;
   bool _showScrollHint = true;
 
+  // Selection mode
+  bool _selectionMode = false;
+  final Set<String> _selectedKeys = {};
+  // When non-null, we're in "adding to album" mode (Flow 2)
+  PhotoAlbum? _addingToAlbum;
+
   ScrollController _scrollController = ScrollController();
 
   @override
@@ -81,6 +102,12 @@ class _PhotosPageState extends State<PhotosPage>
     super.initState();
     _scrollController.addListener(_onScroll);
     WidgetsBinding.instance.addPostFrameCallback((_) => _measureAndJumpNav());
+    // If launched in adding-to-album mode, enter selection mode immediately
+    if (widget.addingToAlbum != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _enterSelectionMode(addingToAlbum: widget.addingToAlbum);
+      });
+    }
   }
 
   void _measureAndJumpNav() {
@@ -520,6 +547,65 @@ class _PhotosPageState extends State<PhotosPage>
     int crossAxisCount,
   ) {
     final p = photos[idx];
+    final isSelected = _selectedKeys.contains(p.selectionKey);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    // In selection mode wrap everything with selection overlay
+    Widget wrapWithSelection(Widget child) {
+      return GestureDetector(
+        onTap: () => _toggleSelection(p),
+        onLongPress: () {
+          if (!_selectionMode) _enterSelectionMode();
+          _toggleSelection(p);
+        },
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            child,
+            // Dim overlay for unselected
+            if (_selectionMode && !isSelected)
+              Container(color: Colors.black.withValues(alpha: 0.3)),
+            // Teal border for selected
+            if (isSelected)
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: colorScheme.primary, width: 3),
+                ),
+              ),
+            // Checkbox in top-left
+            if (_selectionMode)
+              Positioned(
+                top: 6,
+                left: 6,
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  width: 22,
+                  height: 22,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: isSelected
+                        ? colorScheme.primary
+                        : Colors.transparent,
+                    border: Border.all(
+                      color: isSelected
+                          ? colorScheme.primary
+                          : Colors.white.withValues(alpha: 0.8),
+                      width: 2,
+                    ),
+                  ),
+                  child: isSelected
+                      ? const Icon(Icons.check, size: 14, color: Colors.white)
+                      : null,
+                ),
+              ),
+          ],
+        ),
+      );
+    }
+
+    if (!_selectionMode) {
+      // Normal mode — use original long-press to enter selection
+    }
 
     if (p.isCirrus) {
       final c = p.cirrus!;
@@ -527,9 +613,24 @@ class _PhotosPageState extends State<PhotosPage>
         c.apiPath,
         serial: c.deviceSerial,
       );
+      final thumbnail = Image.network(
+        url.toString(),
+        fit: BoxFit.cover,
+        loadingBuilder: (context, child, progress) {
+          if (progress == null) return child;
+          return Container(color: Colors.grey[300]);
+        },
+        errorBuilder: (context, error, stack) =>
+            Container(color: Colors.grey[300]),
+      );
+      if (_selectionMode) return wrapWithSelection(thumbnail);
       return MouseRegion(
         cursor: SystemMouseCursors.click,
         child: GestureDetector(
+          onLongPress: () {
+            _enterSelectionMode();
+            _toggleSelection(p);
+          },
           onTap: () async {
             final navigator = Navigator.of(context);
             final bytes = await CirrusService.downloadFileBytes(
@@ -570,25 +671,29 @@ class _PhotosPageState extends State<PhotosPage>
               ),
             );
           },
-          child: Image.network(
-            url.toString(),
-            fit: BoxFit.cover,
-            loadingBuilder: (context, child, progress) {
-              if (progress == null) return child;
-              return Container(color: Colors.grey[300]);
-            },
-            errorBuilder: (context, error, stack) =>
-                Container(color: Colors.grey[300]),
-          ),
+          child: thumbnail,
         ),
       );
     }
 
     // Mobile asset
     final a = p.asset!;
+    final assetThumb = FutureBuilder<Uint8List?>(
+      future: a.thumbnailDataWithSize(ThumbnailSize(200, 200)),
+      builder: (context, snap) {
+        final thumb = snap.data;
+        if (thumb == null) return Container(color: Colors.grey[300]);
+        return Image.memory(thumb, fit: BoxFit.cover);
+      },
+    );
+    if (_selectionMode) return wrapWithSelection(assetThumb);
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: GestureDetector(
+        onLongPress: () {
+          _enterSelectionMode();
+          _toggleSelection(p);
+        },
         onTap: () async {
           final navigator = Navigator.of(context);
           final bytes = await a.originBytes;
@@ -626,14 +731,7 @@ class _PhotosPageState extends State<PhotosPage>
             ),
           );
         },
-        child: FutureBuilder<Uint8List?>(
-          future: a.thumbnailDataWithSize(ThumbnailSize(200, 200)),
-          builder: (context, snap) {
-            final thumb = snap.data;
-            if (thumb == null) return Container(color: Colors.grey[300]);
-            return Image.memory(thumb, fit: BoxFit.cover);
-          },
-        ),
+        child: assetThumb,
       ),
     );
   }
@@ -679,20 +777,156 @@ class _PhotosPageState extends State<PhotosPage>
     );
   }
 
+  void _enterSelectionMode({PhotoAlbum? addingToAlbum}) {
+    setState(() {
+      _selectionMode = true;
+      _addingToAlbum = addingToAlbum;
+      _selectedKeys.clear();
+    });
+  }
+
+  void _exitSelectionMode() {
+    setState(() {
+      _selectionMode = false;
+      _addingToAlbum = null;
+      _selectedKeys.clear();
+    });
+  }
+
+  void _toggleSelection(PhotoItem item) {
+    setState(() {
+      final key = item.selectionKey;
+      if (_selectedKeys.contains(key)) {
+        _selectedKeys.remove(key);
+      } else {
+        _selectedKeys.add(key);
+      }
+    });
+  }
+
+  Future<void> _handleAddToAlbum(List<PhotoItem> allPhotos) async {
+    final album = await AlbumPickerSheet.show(
+      context,
+      selectedCount: _selectedKeys.length,
+    );
+    if (album == null || !mounted) return;
+    await _addSelectedToAlbum(album, allPhotos);
+  }
+
+  Future<void> _confirmAddToAlbum() async {
+    // Flow 2: user tapped Done while in adding-to-album mode
+    // We need the current photo list — pull from state
+    final photos = _selectedCategory == PhotoCategory.mobile
+        ? _mobilePhotos
+        : _cirrusPhotos;
+    await _addSelectedToAlbum(_addingToAlbum!, photos);
+  }
+
+  Future<void> _addSelectedToAlbum(
+    PhotoAlbum album,
+    List<PhotoItem> allPhotos,
+  ) async {
+    final selected = allPhotos
+        .where((p) => _selectedKeys.contains(p.selectionKey))
+        .toList();
+
+    int added = 0;
+    for (final item in selected) {
+      if (!item.isCirrus) continue;
+      final c = item.cirrus!;
+      try {
+        await AlbumService.addPhotoToAlbum(
+          album.id,
+          deviceSerial: c.deviceSerial,
+          relPath: c.dirPath,
+        );
+        added++;
+      } catch (_) {}
+    }
+
+    if (!mounted) return;
+
+    final wasAddingMode = _addingToAlbum != null;
+    _exitSelectionMode();
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          added == 0
+              ? 'No photos added (only Cirrus photos can be added to albums)'
+              : '$added ${added == 1 ? 'photo' : 'photos'} added to "${album.name}"',
+        ),
+      ),
+    );
+
+    if (wasAddingMode) {
+      // Navigate back to the album page
+      Navigator.of(context).pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AutobutlerAppBar(
-        label: 'Photos',
-        icon: Icons.photo_library_outlined,
-        actions: [
-          RefreshIconButton(
-            isRefreshing: isRefreshing,
-            onPressed: manualRefresh,
-            tooltip: 'Reload photos',
-          ),
-        ],
-      ),
+      appBar: _selectionMode
+          ? AppBar(
+              backgroundColor: Theme.of(context).colorScheme.secondary,
+              automaticallyImplyLeading: false,
+              title: _addingToAlbum != null
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'Adding to ${_addingToAlbum!.name}',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: Theme.of(context).colorScheme.primary,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        if (_selectedKeys.isNotEmpty)
+                          Text(
+                            '${_selectedKeys.length} selected',
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurface.withValues(alpha: 0.5),
+                            ),
+                          ),
+                      ],
+                    )
+                  : Text('${_selectedKeys.length} selected'),
+              actions: [
+                if (_addingToAlbum != null)
+                  TextButton(
+                    onPressed: _selectedKeys.isNotEmpty
+                        ? _confirmAddToAlbum
+                        : null,
+                    child: Text('Done (${_selectedKeys.length})'),
+                  ),
+                TextButton(
+                  onPressed: _exitSelectionMode,
+                  child: const Text('Cancel'),
+                ),
+              ],
+            )
+          : AutobutlerAppBar(
+              label: 'Photos',
+              icon: Icons.photo_library_outlined,
+              actions: [
+                TextButton(
+                  onPressed: _enterSelectionMode,
+                  child: const Text('Select'),
+                ),
+                RefreshIconButton(
+                  isRefreshing: isRefreshing,
+                  onPressed: manualRefresh,
+                  tooltip: 'Reload photos',
+                ),
+              ],
+            ),
       drawer: AutobutlerDrawer(
         activeSection: AutobutlerDrawerSection.photos,
         onTapCirrus: () {
@@ -840,6 +1074,18 @@ class _PhotosPageState extends State<PhotosPage>
                       ],
                     ),
                   ),
+                  // Selection action bar — shown at bottom when in selection mode
+                  if (_selectionMode && _addingToAlbum == null)
+                    Positioned(
+                      bottom: 0,
+                      left: 0,
+                      right: 0,
+                      child: PhotoSelectionBar(
+                        selectedCount: _selectedKeys.length,
+                        onAddToAlbum: () => _handleAddToAlbum(photos),
+                        onCancel: _exitSelectionMode,
+                      ),
+                    ),
                   // Scroll-up hint — subtle chevron at top, fades when user scrolls
                   if (_showScrollHint)
                     Positioned(

--- a/lib/widgets/photos/photo_selection_bar.dart
+++ b/lib/widgets/photos/photo_selection_bar.dart
@@ -87,6 +87,7 @@ class AlbumPickerSheet extends StatefulWidget {
 class _AlbumPickerSheetState extends State<AlbumPickerSheet> {
   List<PhotoAlbum> _albums = [];
   bool _loading = true;
+  bool _error = false;
 
   @override
   void initState() {
@@ -95,6 +96,10 @@ class _AlbumPickerSheetState extends State<AlbumPickerSheet> {
   }
 
   Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = false;
+    });
     try {
       final albums = await AlbumService.listAlbums(tree: true);
       if (!mounted) return;
@@ -104,7 +109,10 @@ class _AlbumPickerSheetState extends State<AlbumPickerSheet> {
       });
     } catch (_) {
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() {
+        _loading = false;
+        _error = true;
+      });
     }
   }
 
@@ -135,6 +143,20 @@ class _AlbumPickerSheetState extends State<AlbumPickerSheet> {
           Expanded(
             child: _loading
                 ? const Center(child: CircularProgressIndicator())
+                : _error
+                ? Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('Failed to load albums'),
+                        const SizedBox(height: 8),
+                        TextButton(
+                          onPressed: _load,
+                          child: const Text('Retry'),
+                        ),
+                      ],
+                    ),
+                  )
                 : _albums.isEmpty
                 ? const Center(
                     child: Text('No albums — create one in the Photos view'),

--- a/lib/widgets/photos/photo_selection_bar.dart
+++ b/lib/widgets/photos/photo_selection_bar.dart
@@ -1,0 +1,171 @@
+import 'package:autobutler/models/photo_album.dart';
+import 'package:autobutler/services/album_service.dart';
+import 'package:autobutler/theme/autobutler_colors.dart';
+import 'package:flutter/material.dart';
+
+/// Sticky bottom bar shown during photo selection mode.
+/// Shows count + "Add to Album" button.
+class PhotoSelectionBar extends StatelessWidget {
+  const PhotoSelectionBar({
+    required this.selectedCount,
+    required this.onAddToAlbum,
+    required this.onCancel,
+    super.key,
+  });
+
+  final int selectedCount;
+  final VoidCallback onAddToAlbum;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return SafeArea(
+      top: false,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          border: Border(top: BorderSide(color: colorScheme.outline)),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.2),
+              blurRadius: 8,
+              offset: const Offset(0, -2),
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            TextButton(onPressed: onCancel, child: const Text('Cancel')),
+            const Spacer(),
+            Text(
+              '$selectedCount ${selectedCount == 1 ? 'photo' : 'photos'} selected',
+              style: TextStyle(
+                fontSize: 13,
+                color: colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+            const Spacer(),
+            FilledButton.icon(
+              onPressed: selectedCount > 0 ? onAddToAlbum : null,
+              icon: const Icon(Icons.photo_album_outlined, size: 16),
+              label: const Text('Add to Album'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Bottom sheet for picking an album to add selected photos to.
+/// Shows album list; on tap calls [onAlbumPicked].
+class AlbumPickerSheet extends StatefulWidget {
+  const AlbumPickerSheet({required this.selectedCount, super.key});
+
+  final int selectedCount;
+
+  static Future<PhotoAlbum?> show(
+    BuildContext context, {
+    required int selectedCount,
+  }) {
+    return showModalBottomSheet<PhotoAlbum>(
+      context: context,
+      isScrollControlled: true,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AutobutlerColors.radiusLg),
+      ),
+      builder: (_) => AlbumPickerSheet(selectedCount: selectedCount),
+    );
+  }
+
+  @override
+  State<AlbumPickerSheet> createState() => _AlbumPickerSheetState();
+}
+
+class _AlbumPickerSheetState extends State<AlbumPickerSheet> {
+  List<PhotoAlbum> _albums = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    try {
+      final albums = await AlbumService.listAlbums(tree: true);
+      if (!mounted) return;
+      setState(() {
+        _albums = albums;
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.5,
+      minChildSize: 0.3,
+      maxChildSize: 0.85,
+      builder: (ctx, sc) => Column(
+        children: [
+          const SizedBox(height: 8),
+          Container(
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.outline,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Add ${widget.selectedCount} ${widget.selectedCount == 1 ? 'photo' : 'photos'} to...',
+            style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+          const SizedBox(height: 4),
+          Expanded(
+            child: _loading
+                ? const Center(child: CircularProgressIndicator())
+                : _albums.isEmpty
+                ? const Center(
+                    child: Text('No albums — create one in the Photos view'),
+                  )
+                : ListView(
+                    controller: sc,
+                    children: _buildAlbumList(_albums, 0),
+                  ),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildAlbumList(List<PhotoAlbum> albums, int depth) {
+    final widgets = <Widget>[];
+    for (final album in albums) {
+      widgets.add(
+        ListTile(
+          contentPadding: EdgeInsets.only(left: 16.0 + depth * 16.0, right: 16),
+          leading: const Icon(Icons.photo_album_outlined),
+          title: Text(album.name),
+          subtitle: Text('${album.itemCount} photos'),
+          onTap: () => Navigator.of(context).pop(album),
+        ),
+      );
+      if (album.children.isNotEmpty) {
+        widgets.addAll(_buildAlbumList(album.children, depth + 1));
+      }
+    }
+    return widgets;
+  }
+}


### PR DESCRIPTION
## Summary

Implements the photo selection UI and both add-to-album flows from issue #971.

## Flow 1 — Library-first

1. Tap **Select** in the Photos header (or long-press any photo on mobile)
2. Selection mode activates — circular checkboxes appear on every tile
3. Tap tiles to select/deselect. Count badge updates in real time.
4. Sticky **PhotoSelectionBar** appears at the bottom: count + **Add to Album** button
5. Tapping Add to Album opens an **AlbumPickerSheet** — scrollable tree of all albums
6. Pick an album → selected Cirrus photos are added via `AlbumService` → snackbar confirmation

## Flow 2 — Album-first

1. Open an album → tap **Add Photos** in the header
2. `PhotosPage` is pushed with `addingToAlbum: album` parameter
3. AppBar transforms: shows "Adding to [Album Name]" with **Done (N)** and **Cancel**
4. Selection mode is active immediately on arrival
5. **Done**: adds selected photos to the album, pops back to AlbumPage (which reloads)
6. **Cancel**: pops back to album unchanged

## Selection UX details

- Long-press to enter selection mode on mobile (natural gesture)
- `Select` button in header for explicit entry
- `PhotoItem.selectionKey` provides stable identity for the selection `Set<String>`
- Animated circular checkbox (150ms) in top-left of each tile
- Selected tiles: teal border + unselected tiles dimmed (30% black overlay)
- Cancel or Done exits selection mode and clears the set

## Files changed

- `lib/pages/photos_page.dart` — selection state, mode methods, updated AppBar, tile wrappers, action bar
- `lib/pages/album_page.dart` — Add Photos button + `_openAddPhotosMode()`
- `lib/widgets/photos/photo_selection_bar.dart` — `PhotoSelectionBar` + `AlbumPickerSheet`

Closes #971
Related: #503, #400, #970