### PR TITLE
fix: center-crop thumbnails instead of squishing non-square images

### DIFF
--- a/internal/server/api/v1/thumbnails/get_thumbnail.go
+++ b/internal/server/api/v1/thumbnails/get_thumbnail.go
@@ -35,10 +35,14 @@ func thumbnailCacheDir() (string, error) {
 	return cacheDir, nil
 }
 
+// thumbnailCacheVersion is bumped whenever the thumbnail generation algorithm
+// changes, so that stale cached thumbnails are automatically regenerated.
+const thumbnailCacheVersion = "v2"
+
 // cacheKey computes a SHA-256 hex digest of the given serial and file path,
 // used as the filename in the cache directory.
 func cacheKey(serial, filePath string) string {
-	h := sha256.Sum256([]byte(serial + "/" + filePath))
+	h := sha256.Sum256([]byte(thumbnailCacheVersion + ":" + serial + "/" + filePath))
 	return fmt.Sprintf("%x", h)
 }
 

--- a/pkg/util/photoutil/photoutil.go
+++ b/pkg/util/photoutil/photoutil.go
@@ -77,8 +77,44 @@ func ImageToThumbnail(filePath string, width, height uint) (image.Image, string,
 
 	img, _ = CorrectImageOrientation(img, file)
 
-	thumbnail := resize.Resize(width, height, img, resize.Lanczos3)
-	return thumbnail, format, nil
+	// Scale so the shorter side fills the target dimension, then center-crop.
+	// This preserves aspect ratio rather than squishing the image.
+	bounds := img.Bounds()
+	srcW := uint(bounds.Dx())
+	srcH := uint(bounds.Dy())
+
+	var scaledW, scaledH uint
+	if srcW*height > srcH*width {
+		// Image is wider than target: scale by height, crop width
+		scaledH = height
+		scaledW = srcW * height / srcH
+	} else {
+		// Image is taller than target: scale by width, crop height
+		scaledW = width
+		scaledH = srcH * width / srcW
+	}
+
+	scaled := resize.Resize(scaledW, scaledH, img, resize.Lanczos3)
+
+	scaledBounds := scaled.Bounds()
+	x0 := (scaledBounds.Dx() - int(width)) / 2
+	y0 := (scaledBounds.Dy() - int(height)) / 2
+
+	type subImager interface {
+		SubImage(r image.Rectangle) image.Image
+	}
+	if si, ok := scaled.(subImager); ok {
+		return si.SubImage(image.Rect(x0, y0, x0+int(width), y0+int(height))), format, nil
+	}
+
+	// Fallback: manual pixel copy (resize library always returns a subImager in practice)
+	cropped := image.NewRGBA(image.Rect(0, 0, int(width), int(height)))
+	for y := 0; y < int(height); y++ {
+		for x := 0; x < int(width); x++ {
+			cropped.Set(x, y, scaled.At(x0+x, y0+y))
+		}
+	}
+	return cropped, format, nil
 }
 
 // CorrectImageOrientation reads EXIF orientation data and rotates/flips the image accordingly.

--- a/pkg/util/photoutil/photoutil_test.go
+++ b/pkg/util/photoutil/photoutil_test.go
@@ -102,8 +102,40 @@ func TestImageToThumbnail(t *testing.T) {
 	}
 
 	bounds := thumbnail.Bounds()
-	if bounds.Dx() > 50 || bounds.Dy() > 50 {
-		t.Errorf("Thumbnail too large: %dx%d", bounds.Dx(), bounds.Dy())
+	if bounds.Dx() != 50 || bounds.Dy() != 50 {
+		t.Errorf("Expected 50x50 thumbnail, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestImageToThumbnail_NonSquareLandscape(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "landscape.png")
+	createTestImage(t, imagePath, 400, 200) // 2:1 landscape
+
+	thumbnail, _, err := ImageToThumbnail(imagePath, 50, 50)
+	if err != nil {
+		t.Fatalf("ImageToThumbnail failed: %v", err)
+	}
+
+	bounds := thumbnail.Bounds()
+	if bounds.Dx() != 50 || bounds.Dy() != 50 {
+		t.Errorf("Expected 50x50 thumbnail, got %dx%d (landscape input must be cropped, not squished)", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestImageToThumbnail_NonSquarePortrait(t *testing.T) {
+	tmpDir := t.TempDir()
+	imagePath := filepath.Join(tmpDir, "portrait.png")
+	createTestImage(t, imagePath, 200, 400) // 1:2 portrait
+
+	thumbnail, _, err := ImageToThumbnail(imagePath, 50, 50)
+	if err != nil {
+		t.Fatalf("ImageToThumbnail failed: %v", err)
+	}
+
+	bounds := thumbnail.Bounds()
+	if bounds.Dx() != 50 || bounds.Dy() != 50 {
+		t.Errorf("Expected 50x50 thumbnail, got %dx%d (portrait input must be cropped, not squished)", bounds.Dx(), bounds.Dy())
 	}
 }
 
@@ -373,7 +405,7 @@ func TestImageToThumbnail_WithEXIF(t *testing.T) {
 	}
 
 	bounds := thumbnail.Bounds()
-	if bounds.Dx() > 100 || bounds.Dy() > 100 {
-		t.Errorf("Thumbnail too large: %dx%d", bounds.Dx(), bounds.Dy())
+	if bounds.Dx() != 100 || bounds.Dy() != 100 {
+		t.Errorf("Expected 100x100 thumbnail, got %dx%d", bounds.Dx(), bounds.Dy())
 	}
 }


### PR DESCRIPTION
Closes #980

## Summary
- `ImageToThumbnail` was calling `resize.Resize(w, h, img)` with both dimensions set, which forces the image to exactly that size and distorts the aspect ratio of non-square photos
- Replace with scale-then-center-crop: scale so the shorter side fills the target dimension, then crop the center to the target square
- Bump thumbnail cache key to `v2` so existing squished thumbnails are regenerated on next request

## Test plan
- [ ] Added unit tests for landscape and portrait inputs — both must produce exactly the target dimensions
- [ ] Tightened existing square test from `> 50` to `!= 50`
- [ ] Run `make test/unit/backend` — all pass