### PR TITLE
feat: Create armbian-based autobutler OS image

### DIFF
--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -98,5 +98,6 @@ jobs:
             --source build/output/images/ \
             --destination "https://autobutlerrelease.blob.core.windows.net/releases" \
             --destination-path "autobutler/${{ steps.resolve-tag.outputs.autobutler_tag }}/${{ matrix.board }}" \
+            --tier Hot \
             --sas-token "${AZURE_STORAGE_SAS_TOKEN}" \
             --overwrite

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -1,7 +1,6 @@
 name: Autobutler Armbian Build
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       autobutler_tag:

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -85,6 +85,6 @@ jobs:
           az storage blob upload-batch \
             --source build/output/images/ \
             --destination "https://autobutlerrelease.blob.core.windows.net/releases" \
-            --destination-path "autobutler/${{ inputs.autobutler_tag }}/${{ matrix.board }}" \
+            --destination-path "autobutler/${{ steps.resolve-tag.outputs.autobutler_tag }}/${{ matrix.board }}" \
             --sas-token "${AZURE_STORAGE_SAS_TOKEN}" \
             --overwrite

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -46,6 +46,11 @@ jobs:
     outputs:
       autobutler_tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
       - name: Resolve Autobutler tag
         id: resolve-tag
         env:

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -77,6 +77,7 @@ jobs:
           armbian_board: ${{ matrix.board }}
           armbian_release: ${{ inputs.armbian_release }}
           armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+          armbian_extensions: autobutler-image
 
       - name: Rename images
         run: |

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -32,10 +32,11 @@ jobs:
     permissions:
       contents: write
     strategy:
+      fail-fast: false
       matrix:
         board:
           - rpi4b
-          - odroid-n2
+          - odroidn2
     outputs:
       autobutler_tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
     steps:

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -81,7 +81,7 @@ jobs:
         uses: ./armbian-build
         with:
           armbian_token: ${{ secrets.armbian_token || github.token }}
-          armbian_target: image
+          armbian_target: build
           armbian_board: ${{ inputs.armbian_board }}
           armbian_release: ${{ inputs.armbian_release }}
           armbian_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -45,6 +45,7 @@ jobs:
       contents: write
     outputs:
       autobutler_tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+      armbian_revision: ${{ steps.resolve-tag.outputs.armbian_revision }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -74,7 +75,16 @@ jobs:
             exit 1
           fi
 
+          REVISION_TAG="${TAG#v}"
+          REVISION_TAG="${REVISION_TAG#V}"
+
+          if [[ ! "${REVISION_TAG}" =~ ^[0-9] ]]; then
+            echo "Resolved Autobutler tag '${TAG}' is not valid for Armbian REVISION"
+            exit 1
+          fi
+
           echo "autobutler_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "armbian_revision=${REVISION_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved Autobutler tag: ${TAG}"
 
       - name: Build image with embedded Autobutler tag
@@ -84,7 +94,7 @@ jobs:
           armbian_target: build
           armbian_board: ${{ inputs.armbian_board }}
           armbian_release: ${{ inputs.armbian_release }}
-          armbian_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+          armbian_version: ${{ steps.resolve-tag.outputs.armbian_revision }}
           armbian_version_mode: exact
           armbian_release_title: Autobutler Armbian image (${{ steps.resolve-tag.outputs.autobutler_tag }})
           armbian_release_body: |

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -7,14 +7,6 @@ on:
         description: "Autobutler release tag to embed (for example: v1.2.3). Leave empty to use latest release"
         required: false
         type: string
-      armbian_board:
-        description: "Armbian board (for example: rpi4b, rpi5b, uefi-x86)"
-        required: false
-        type: choice
-        default: rpi4b
-        options:
-          - rpi4b
-          - odroid-n2
       armbian_release:
         description: "Armbian userspace release"
         required: false
@@ -25,10 +17,6 @@ on:
       autobutler_tag:
         required: false
         type: string
-      armbian_board:
-        required: false
-        type: string
-        default: rpi4b
       armbian_release:
         required: false
         type: string
@@ -43,9 +31,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    strategy:
+      matrix:
+        board:
+          - rpi4b
+          - odroid-n2
     outputs:
       autobutler_tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
-      armbian_revision: ${{ steps.resolve-tag.outputs.armbian_revision }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -75,16 +67,7 @@ jobs:
             exit 1
           fi
 
-          REVISION_TAG="${TAG#v}"
-          REVISION_TAG="${REVISION_TAG#V}"
-
-          if [[ ! "${REVISION_TAG}" =~ ^[0-9] ]]; then
-            echo "Resolved Autobutler tag '${TAG}' is not valid for Armbian REVISION"
-            exit 1
-          fi
-
           echo "autobutler_tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "armbian_revision=${REVISION_TAG}" >> "$GITHUB_OUTPUT"
           echo "Resolved Autobutler tag: ${TAG}"
 
       - name: Build image with embedded Autobutler tag
@@ -92,10 +75,9 @@ jobs:
         with:
           armbian_token: ${{ secrets.armbian_token || github.token }}
           armbian_target: build
-          armbian_board: ${{ inputs.armbian_board }}
+          armbian_board: ${{ matrix.board }}
           armbian_release: ${{ inputs.armbian_release }}
-          armbian_version: ${{ steps.resolve-tag.outputs.armbian_revision }}
-          armbian_version_mode: exact
+          armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
           armbian_release_title: Autobutler Armbian image (${{ steps.resolve-tag.outputs.autobutler_tag }})
           armbian_release_body: |
             Autobutler Armbian image build.

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          fetch-depth: 1
 
       - name: Resolve Autobutler tag
         id: resolve-tag

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -1,5 +1,9 @@
 name: Autobutler Armbian Build
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -72,6 +72,8 @@ jobs:
 
       - name: Build image with embedded Autobutler tag
         uses: ./armbian-build
+        env:
+          AUTOBUTLER_IMAGE_BINARY_URL: https://autobutlerrelease.blob.core.windows.net/releases/autobutler/${{ steps.resolve-tag.outputs.autobutler_tag }}/autobutler_Linux_arm64.tar.gz
         with:
           armbian_target: build
           armbian_board: ${{ matrix.board }}

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -79,8 +79,12 @@ jobs:
           armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
 
       - name: Upload images to Azure Blob Storage
+        env:
+          AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}
         run: |
           az storage blob upload-batch \
             --source build/output/images/ \
-            --destination "https://autobutlerimage.blob.core.windows.net/releases/armbian/${{ matrix.board }}/${{ steps.resolve-tag.outputs.autobutler_tag }}?${{ secrets.AZURE_STORAGE_SAS_TOKEN_autobutlerimage }}" \
+            --destination "https://autobutlerrelease.blob.core.windows.net/releases" \
+            --destination-path "autobutler/${{ inputs.autobutler_tag }}/${{ matrix.board }}" \
+            --sas-token "${AZURE_STORAGE_SAS_TOKEN}" \
             --overwrite

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -1,4 +1,4 @@
-name: Autobutler Armbian Build
+name: Armbian Build
 
 permissions:
   contents: read

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -1,6 +1,7 @@
 name: Autobutler Armbian Build
 
 on:
+  push:
   workflow_dispatch:
     inputs:
       autobutler_tag:

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -1,0 +1,85 @@
+name: Autobutler Armbian Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      autobutler_tag:
+        description: "Autobutler release tag to embed (for example: v1.2.3). Leave empty to use latest release"
+        required: false
+        type: string
+      armbian_board:
+        description: "Armbian board (for example: rpi4b, rpi5b, uefi-x86)"
+        required: false
+        type: string
+        default: "uefi-x86"
+      armbian_release:
+        description: "Armbian userspace release"
+        required: false
+        type: string
+        default: "noble"
+  workflow_call:
+    inputs:
+      autobutler_tag:
+        required: false
+        type: string
+      armbian_board:
+        required: false
+        type: string
+        default: "uefi-x86"
+      armbian_release:
+        required: false
+        type: string
+        default: "noble"
+    secrets:
+      armbian_token:
+        required: false
+
+jobs:
+  armbian-build:
+    name: Build Armbian image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      autobutler_tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+    steps:
+      - name: Resolve Autobutler tag
+        id: resolve-tag
+        env:
+          INPUT_TAG: ${{ inputs.autobutler_tag }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${INPUT_TAG}" ]; then
+            TAG="${INPUT_TAG#refs/tags/}"
+          else
+            TAG="$(curl -fsSL \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              https://api.github.com/repos/autobutler-org/autobutler/releases/latest | jq -r '.tag_name')"
+          fi
+
+          if [ -z "${TAG}" ] || [ "${TAG}" = "null" ]; then
+            echo "Failed to resolve Autobutler tag"
+            exit 1
+          fi
+
+          echo "autobutler_tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved Autobutler tag: ${TAG}"
+
+      - name: Build image with embedded Autobutler tag
+        uses: ./armbian-build
+        with:
+          armbian_token: ${{ secrets.armbian_token || github.token }}
+          armbian_target: image
+          armbian_board: ${{ inputs.armbian_board }}
+          armbian_release: ${{ inputs.armbian_release }}
+          armbian_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+          armbian_version_mode: exact
+          armbian_release_title: Autobutler Armbian image (${{ steps.resolve-tag.outputs.autobutler_tag }})
+          armbian_release_body: |
+            Autobutler Armbian image build.
+
+            Embedded Autobutler tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+          armbian_release_tag: armbian-${{ steps.resolve-tag.outputs.autobutler_tag }}

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -21,16 +21,11 @@ on:
         required: false
         type: string
         default: noble
-    secrets:
-      armbian_token:
-        required: false
 
 jobs:
   armbian-build:
     name: Build Armbian image
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -74,14 +69,7 @@ jobs:
       - name: Build image with embedded Autobutler tag
         uses: ./armbian-build
         with:
-          armbian_token: ${{ secrets.armbian_token || github.token }}
           armbian_target: build
           armbian_board: ${{ matrix.board }}
           armbian_release: ${{ inputs.armbian_release }}
           armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
-          armbian_release_title: Autobutler Armbian image (${{ steps.resolve-tag.outputs.autobutler_tag }})
-          armbian_release_body: |
-            Autobutler Armbian image build.
-
-            Embedded Autobutler tag: ${{ steps.resolve-tag.outputs.autobutler_tag }}
-          armbian_release_tag: armbian-${{ steps.resolve-tag.outputs.autobutler_tag }}

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -77,3 +77,13 @@ jobs:
           armbian_board: ${{ matrix.board }}
           armbian_release: ${{ inputs.armbian_release }}
           armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
+
+      - name: Upload images to Azure Blob Storage
+        run: |
+          az storage blob upload-batch \
+            --account-name autobutlerimage \
+            --destination releases \
+            --destination-path "armbian/${{ matrix.board }}/${{ steps.resolve-tag.outputs.autobutler_tag }}" \
+            --source build/output/images/ \
+            --sas-token "${{ secrets.AZURE_STORAGE_SAS_TOKEN_autobutlerimage }}" \
+            --overwrite

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -81,9 +81,6 @@ jobs:
       - name: Upload images to Azure Blob Storage
         run: |
           az storage blob upload-batch \
-            --account-name autobutlerimage \
-            --destination releases \
-            --destination-path "armbian/${{ matrix.board }}/${{ steps.resolve-tag.outputs.autobutler_tag }}" \
             --source build/output/images/ \
-            --sas-token "${{ secrets.AZURE_STORAGE_SAS_TOKEN_autobutlerimage }}" \
+            --destination "https://autobutlerimage.blob.core.windows.net/releases/armbian/${{ matrix.board }}/${{ steps.resolve-tag.outputs.autobutler_tag }}?${{ secrets.AZURE_STORAGE_SAS_TOKEN_autobutlerimage }}" \
             --overwrite

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -78,6 +78,15 @@ jobs:
           armbian_release: ${{ inputs.armbian_release }}
           armbian_image_version: ${{ steps.resolve-tag.outputs.autobutler_tag }}
 
+      - name: Rename images
+        run: |
+          for ext in img.xz.sha img.xz img.txt; do
+            src=$(find build/output/images/ -maxdepth 1 -name "*.${ext}" | head -1)
+            if [ -n "${src}" ]; then
+              mv "${src}" "build/output/images/autobutler-armbian.${ext}"
+            fi
+          done
+
       - name: Upload images to Azure Blob Storage
         env:
           AZURE_STORAGE_SAS_TOKEN: ${{ secrets.AZURE_STORAGE_SAS_TOKEN }}

--- a/.github/workflows/autobutler-armbian-build.yml
+++ b/.github/workflows/autobutler-armbian-build.yml
@@ -10,13 +10,16 @@ on:
       armbian_board:
         description: "Armbian board (for example: rpi4b, rpi5b, uefi-x86)"
         required: false
-        type: string
-        default: "uefi-x86"
+        type: choice
+        default: rpi4b
+        options:
+          - rpi4b
+          - odroid-n2
       armbian_release:
         description: "Armbian userspace release"
         required: false
         type: string
-        default: "noble"
+        default: noble
   workflow_call:
     inputs:
       autobutler_tag:
@@ -25,11 +28,11 @@ on:
       armbian_board:
         required: false
         type: string
-        default: "uefi-x86"
+        default: rpi4b
       armbian_release:
         required: false
         type: string
-        default: "noble"
+        default: noble
     secrets:
       armbian_token:
         required: false

--- a/.github/workflows/autobutler-release.yml
+++ b/.github/workflows/autobutler-release.yml
@@ -53,3 +53,11 @@ jobs:
         with:
           name: autobutler-release
           path: ${{ env.WORKING_DIR }}/dist/*
+
+  armbian-build:
+    needs: autobutler-release
+    if: success() && startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/autobutler-armbian-build.yml
+    with:
+      autobutler_tag: ${{ github.ref_name }}
+    secrets: inherit

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "armbian-build"]
+	path = armbian-build
+	url = https://github.com/autobutler-org/armbian-build
+	branch = 922-armbian-autobutler-image

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "armbian-build"]
 	path = armbian-build
 	url = https://github.com/autobutler-org/armbian-build
-	branch = 922-armbian-autobutler-image
+	branch = main

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
   "cSpell.words": [
     "APFS",
     "Appstore",
+    "armbian",
     "autobutler",
     "Autobutler",
     "autobutlerrelease",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You buy the hardware once. No subscriptions. No data mining. It's yours.
 **Prerequisites:** Go, Flutter, Make, [air](https://github.com/air-verse/air), sqlc, swag
 
 ```bash
-git clone https://github.com/autobutler-org/autobutler.git
+git clone https://github.com/autobutler-org/autobutler.git # Include --recursive if you want to do OS image builds
 cd autobutler
 make setup
 make generate
@@ -37,16 +37,19 @@ make build
 ### Run it locally
 
 Backend with hot reload:
+
 ```bash
 make watch/backend
 ```
 
 Frontend (web):
+
 ```bash
 make serve/frontend
 ```
 
 Frontend (mobile emulator):
+
 ```bash
 make emulate          # default platform
 make emulate/android  # or emulate/ios

--- a/os/scripts/provision.sh
+++ b/os/scripts/provision.sh
@@ -120,6 +120,16 @@ mkdir -p "$(rpath "$DEST_BIN_DIR")"
 mkdir -p "$(rpath "$SYSTEMD_DIR")"
 mkdir -p "$(rpath "$AVAHI_DIR")"
 
+# Ensure autobutler system user exists (idempotent)
+if [[ "$ROOT_DIR" == "/" ]]; then
+  if ! id -u autobutler >/dev/null 2>&1; then
+    info "Creating system user: autobutler"
+    useradd --system --no-create-home --shell /usr/sbin/nologin autobutler
+  else
+    info "System user autobutler already exists"
+  fi
+fi
+
 # Install binary (if provided)
 if [[ -n "$BINARY_PATH" ]]; then
   info "Installing binary to ${DEST_BIN_DIR}/${BINARY_NAME}"
@@ -136,15 +146,18 @@ info "Writing systemd unit to ${UNIT_PATH_REL}"
 cat > "$UNIT_PATH.tmp" <<'UNIT'
 [Unit]
 Description=Autobutler service
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/autobutler
+User=autobutler
+Group=autobutler
+ExecStart=/usr/local/bin/autobutler serve
 Restart=on-failure
 RestartSec=5s
-User=root
-Group=root
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #922

## What

Adds an Armbian-based OS image build pipeline for Autobutler, replacing the previous approach of trying to cross-compile via QEMU. The build uses the official [armbian-build](https://github.com/armbian/build) framework as a Git submodule and produces a ready-to-flash image with Autobutler pre-installed and configured.

## Changes

### New: `.github/workflows/autobutler-armbian-build.yml`
- Dedicated workflow (`workflow_dispatch`) triggered manually or from the release pipeline
- Clones the repo with `--recursive` to initialise the `armbian-build` submodule
- Matrix build over supported boards (e.g. `odroidn2`)
- Invokes the Armbian build framework with the `autobutler-image` extension enabled and `AUTOBUTLER_IMAGE_BINARY_URL` overridden to point at the release artifact
- Uploads the produced `.img` to Azure Blob Storage (`autobutlerrelease` container, hot tier) and renames files before upload for consistent naming
- Workflow permissions hardened per CodeQL finding (explicit `contents: write`, no wildcard)

### New: `armbian-build` (Git submodule)
- Points at the Armbian build framework repository
- Submodule ref kept at a tested tip

### New: `.gitmodules`
- Registers `armbian-build` submodule

### Updated: `.github/workflows/autobutler-release.yml`
- Triggers `autobutler-armbian-build.yml` at the end of the release pipeline so a new OS image is produced for every tagged release

### Updated: `os/scripts/provision.sh`
- Fixes bind capabilities for the systemd service
- Additional provisioning improvements accumulated during image testing

### Updated: `README.md`
- Notes on OS image availability and the Armbian-based build

### Updated: `.vscode/settings.json`
- Minor workspace settings tweak

## Build flow

```
git push tag vX.Y.Z
  └── autobutler-release.yml
        └── autobutler-armbian-build.yml
              └── armbian-build framework (board matrix)
                    └── provisions Autobutler binary + systemd service
                          └── uploads <board>-autobutler.img to Azure hot tier
```

## PR type
- [x] Feature / infrastructure

## Surface
- [x] CI (`.github/workflows/`)
- [x] OS image build (`os/`, `armbian-build`)
