### PR TITLE
feat: add route-driven cirrus folder navigation

### DIFF
--- a/internal/server/api/v1/cirrus/cirrus_integration_test.go
+++ b/internal/server/api/v1/cirrus/cirrus_integration_test.go
@@ -208,6 +208,15 @@ func TestUploadToSubdirectory(t *testing.T) {
 	}
 }
 
+func TestListFiles_NonExistentSubdirectoryReturnsNotFound(t *testing.T) {
+	engine, _ := newTestEngine(t)
+
+	w := doRequest(engine, http.MethodGet, "/api/v1/cirrus?rootDir=ghosts", nil, "")
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestDownloadFile(t *testing.T) {
 	engine, cirrusDir := newTestEngine(t)
 

--- a/internal/server/api/v1/cirrus/cirrus_test.go
+++ b/internal/server/api/v1/cirrus/cirrus_test.go
@@ -164,13 +164,14 @@ func TestListFilesImpl_NoDevices(t *testing.T) {
 func TestListFilesImpl_NonExistentSubdir(t *testing.T) {
 	device := makeManagedDevice(t, "test-device")
 
-	// Listing a subdir that doesn't exist should return empty, not error
+	// Listing a subdir that doesn't exist should fail so the client can render
+	// an explicit invalid-folder state instead of an empty listing.
 	result, err := listFilesImpl("nonexistent", []storageutil.ManagedDevice{device})
-	if err != nil {
-		t.Fatalf("Expected no error for nonexistent subdir, got: %v", err)
+	if err == nil {
+		t.Fatal("expected an error for a nonexistent subdir")
 	}
-	if len(result) != 0 {
-		t.Errorf("Expected 0 results for nonexistent subdir, got %d", len(result))
+	if result != nil {
+		t.Errorf("expected no results for nonexistent subdir, got %d", len(result))
 	}
 }
 

--- a/internal/server/api/v1/cirrus/list_files.go
+++ b/internal/server/api/v1/cirrus/list_files.go
@@ -1,6 +1,8 @@
 package v1_files
 
 import (
+	"errors"
+	"net/http"
 	"path/filepath"
 
 	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
@@ -28,6 +30,8 @@ type FileNodeJSON struct {
 
 func listFilesImpl(rootDir string, devices []storageutil.ManagedDevice) ([]FileNodeJSON, error) {
 	var allFiles []*storageutil.DeviceFileInfo
+	sawListing := false
+	sawNotFound := false
 	for _, device := range devices {
 		cirrusDir := device.CirrusDir
 		fullPathDir, err := storageutil.SafeJoin(cirrusDir, rootDir)
@@ -40,9 +44,16 @@ func listFilesImpl(rootDir string, devices []storageutil.ManagedDevice) ([]FileN
 		}
 		files, err := storageutil.StatFilesInDir(fullPathDir, device.Name, device.DataDir, deviceSerial)
 		if err != nil {
+			if rootDir != "" && errors.Is(err, storageutil.ErrPathNotFound) {
+				sawNotFound = true
+			}
 			continue
 		}
+		sawListing = true
 		allFiles = append(allFiles, files...)
+	}
+	if rootDir != "" && sawNotFound && !sawListing {
+		return nil, serverutil.NewHttpErrorf(http.StatusNotFound, "folder not found: %s", rootDir)
 	}
 	// Only deduplicate folders (isDir), show all files across all devices
 	seenFolders := make(map[string]bool)

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -21,6 +21,7 @@ import 'package:autobutler/utils/file_browser_drag_config.dart';
 import 'package:autobutler/utils/file_browser_path_utils.dart';
 import 'package:autobutler/utils/safe_set_state_mixin.dart';
 import 'package:autobutler/widgets/autobutler_drawer.dart';
+import 'package:autobutler/widgets/core/empty_state_widget.dart';
 import 'package:autobutler/widgets/device_upload_picker.dart';
 import 'package:autobutler/widgets/file_browser/file_browser_header.dart';
 import 'package:autobutler/widgets/file_browser/file_browser_view.dart';
@@ -1077,31 +1078,75 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     if (normalized == _currentPath) {
       return;
     }
-
-    setState(() {
-      _currentPath = normalized;
-      // Show cached listing instantly while the fresh fetch is in flight.
-      _cachedFiles = FileBrowserCache.instance.get(normalized);
-      // Reset device filter to all devices on navigation.
-      _activeDevicePaths = _allDevices.map((d) => d.devicePath).toSet();
-      _reloadFiles();
-    });
-
-    // Reflect the new folder path in the browser URL bar. Skip during
-    // deep-link processing (_handlingPendingFile) to avoid triggering a
-    // go_router rebuild mid-open that would cancel the pending file open.
-    if (!_handlingPendingFile && kIsWeb) {
-      SystemNavigator.routeInformationUpdated(
-        uri: Uri.parse(AppRoutes.cirrusPath(normalized)),
-        replace: false,
-      );
-    }
+    context.go(AppRoutes.cirrusPath(normalized));
   }
 
   void _showMessage(String message) {
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  void _goHome() {
+    if (_archiveContext != null) {
+      _exitArchive();
+      return;
+    }
+
+    if (_fileBrowserScrollController.hasClients) {
+      _fileBrowserScrollController.jumpTo(0);
+    }
+
+    if (_currentPath.isEmpty) {
+      setState(() {
+        _isSearchMode = false;
+        _searchFuture = null;
+        _searchQuery = null;
+        _activeDevicePaths = _allDevices.map((d) => d.devicePath).toSet();
+        _reloadFiles();
+      });
+      return;
+    }
+
+    _setPath('');
+  }
+
+  Widget _buildFolderRouteErrorState(BuildContext context, Object error) {
+    final isMissingFolder =
+        error is CirrusRequestException && error.statusCode == 404;
+    final normalizedPath = normalizePath(_currentPath);
+    final routeLabel = normalizedPath.isEmpty
+        ? AppRoutes.cirrus
+        : AppRoutes.cirrusPath(normalizedPath);
+    final parent = parentPath(normalizedPath);
+
+    return EmptyStateWidget(
+      icon: isMissingFolder ? Icons.folder_off_outlined : Icons.error_outline,
+      headline: isMissingFolder ? 'Folder not found' : 'Unable to open folder',
+      subtext: isMissingFolder
+          ? 'The folder at $routeLabel is unavailable. Retry, move up a level, or return to /cirrus.'
+          : 'Cirrus could not load $routeLabel. Retry, move up a level, or return to /cirrus.',
+      action: Wrap(
+        alignment: WrapAlignment.center,
+        spacing: 12,
+        runSpacing: 12,
+        children: [
+          FilledButton(
+            onPressed: _refreshFileState,
+            child: const Text('Retry'),
+          ),
+          if (parent.isNotEmpty)
+            OutlinedButton(
+              onPressed: () => _setPath(parent),
+              child: const Text('Go to parent'),
+            ),
+          OutlinedButton(
+            onPressed: _goHome,
+            child: const Text('Go to /cirrus'),
+          ),
+        ],
+      ),
+    );
   }
 
   /// Push a file editor/viewer, update the URL to reflect the open file,
@@ -1402,7 +1447,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
                 isUploading: _isUploading,
                 isCreatingFolder: _isCreatingFolder,
                 isRefreshing: isRefreshing,
-                onGoHome: archive != null ? _exitArchive : () => _setPath(''),
+                onGoHome: archive != null ? _exitArchive : _goHome,
                 onGoUp: _goUpOneLevel,
                 onPathSelected: archive != null ? null : _setPath,
                 isUnifiedView: _isUnifiedView,
@@ -1534,6 +1579,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
                           isSearchMode: _isSearchMode,
                           onNavigateToFolder: _navigateToFolder,
                           currentPath: _currentPath,
+                          errorBuilder: _buildFolderRouteErrorState,
                           onDropToFolder: _handleDropToFolder,
                           onFolderDragEnter: _handleFolderDragEnter,
                           onFolderDragExit: _handleFolderDragExit,

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -69,11 +69,6 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   /// the page has mounted. Only consumed once.
   String? _pendingFileOpen;
 
-  /// True while [_openPendingFile] is running. Prevents [_setPath] from
-  /// calling context.go() during initial deep-link processing, which would
-  /// cause a navigation loop.
-  bool _handlingPendingFile = false;
-
   bool _isGridView = false;
 
   /// When true, files from all devices are shown merged (unified).
@@ -1201,12 +1196,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   /// rather than being launched in the document editor.
   Future<void> _openPendingFile(String filePath) async {
     if (!mounted) return;
-    _handlingPendingFile = true;
-    try {
-      await _openPendingFileInner(filePath);
-    } finally {
-      _handlingPendingFile = false;
-    }
+    await _openPendingFileInner(filePath);
   }
 
   Future<void> _openPendingFileInner(String filePath) async {

--- a/lib/services/cirrus_service.dart
+++ b/lib/services/cirrus_service.dart
@@ -12,6 +12,19 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_file_dialog/flutter_file_dialog.dart';
 import 'package:http/http.dart' as http;
 
+class CirrusRequestException implements Exception {
+  const CirrusRequestException({
+    required this.statusCode,
+    required this.message,
+  });
+
+  final int statusCode;
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 class CirrusService with AuthenticatedService {
   static final CirrusService _instance = CirrusService._();
   CirrusService._();
@@ -38,6 +51,24 @@ class CirrusService with AuthenticatedService {
     }
 
     return uri;
+  }
+
+  static String _responseMessage(
+    http.Response response, {
+    required String fallback,
+  }) {
+    try {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        final error = decoded['error'];
+        if (error is String && error.trim().isNotEmpty) {
+          return error;
+        }
+      }
+    } catch (_) {
+      // Fall back to the caller-provided message when the response is not JSON.
+    }
+    return fallback;
   }
 
   static Uri constructMediaUrl(String filePath, {String? serial}) {
@@ -147,7 +178,13 @@ class CirrusService with AuthenticatedService {
 
     final response = await http.get(uri, headers: _authHeaders);
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw Exception('Failed to load cirrus files (${response.statusCode})');
+      throw CirrusRequestException(
+        statusCode: response.statusCode,
+        message: _responseMessage(
+          response,
+          fallback: 'Failed to load cirrus files (${response.statusCode})',
+        ),
+      );
     }
 
     final decoded = jsonDecode(response.body);
@@ -327,7 +364,13 @@ class CirrusService with AuthenticatedService {
     final uri = endpointUri.replace(query: querySegments.join('&'));
     final response = await http.get(uri, headers: _authHeaders);
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw Exception('Failed to stat file (${response.statusCode})');
+      throw CirrusRequestException(
+        statusCode: response.statusCode,
+        message: _responseMessage(
+          response,
+          fallback: 'Failed to stat file (${response.statusCode})',
+        ),
+      );
     }
     final decoded = jsonDecode(response.body);
     if (decoded is! Map<String, dynamic>) {

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -40,6 +40,7 @@ class FileBrowserView extends StatefulWidget {
     this.onNavigateToFolder,
     this.inArchive = false,
     this.isInitialLoad = false,
+    this.errorBuilder,
     super.key,
   });
 
@@ -71,6 +72,7 @@ class FileBrowserView extends StatefulWidget {
   /// empty default future would immediately show "No files yet" instead of
   /// a spinner.
   final bool isInitialLoad;
+  final Widget Function(BuildContext context, Object error)? errorBuilder;
 
   @override
   State<FileBrowserView> createState() => _FileBrowserViewState();
@@ -362,6 +364,10 @@ class _FileBrowserViewState extends State<FileBrowserView> {
         }
 
         if (snapshot.hasError) {
+          final error = snapshot.error!;
+          if (widget.errorBuilder != null) {
+            return widget.errorBuilder!(context, error);
+          }
           return Center(
             child: Text(
               'Unable to load files',

--- a/pkg/util/storageutil/storageutil.go
+++ b/pkg/util/storageutil/storageutil.go
@@ -1,6 +1,7 @@
 package storageutil
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -13,6 +14,8 @@ import (
 )
 
 type FileType string
+
+var ErrPathNotFound = errors.New("path not found")
 
 const (
 	FileTypeAbdoc     FileType = "abdoc"
@@ -160,6 +163,9 @@ func StatFilesInDir(dir string, deviceName string, devicePath string, deviceSeri
 	entries, err := os.ReadDir(dir)
 	files := make([]*DeviceFileInfo, 0, len(entries))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("%w: %s", ErrPathNotFound, dir)
+		}
 		return nil, fmt.Errorf("error reading the directory %s: %w", dir, err) // coverage: ignore - requires filesystem permission errors
 	}
 	for _, entry := range entries {


### PR DESCRIPTION
## Summary
- return 404 for missing Cirrus folder routes so invalid deep links are explicit instead of empty listings
- switch Cirrus folder navigation to router-owned context.go path updates
- render a dedicated folder route error state with retry, parent, and root recovery actions

Closes #1048
