### PR TITLE
feat: improve cirrus folder deep-link startup

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1106,9 +1106,44 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     _setPath('');
   }
 
+  Widget _buildFolderResolutionLoadingShell(BuildContext context) {
+    final routeLabel = AppRoutes.cirrusPath(_currentPath);
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.folder_open, size: 48),
+              const SizedBox(height: 16),
+              Text(
+                'Opening folder',
+                style: Theme.of(context).textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                routeLabel,
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              const LinearProgressIndicator(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   Widget _buildFolderRouteErrorState(BuildContext context, Object error) {
-    final isMissingFolder =
-        error is CirrusRequestException && error.statusCode == 404;
+    final requestError = error is CirrusRequestException ? error : null;
+    final isMissingFolder = requestError?.statusCode == 404;
+    final isUnauthorized =
+        requestError?.statusCode == 401 || requestError?.statusCode == 403;
     final normalizedPath = normalizePath(_currentPath);
     final routeLabel = normalizedPath.isEmpty
         ? AppRoutes.cirrus
@@ -1116,9 +1151,19 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     final parent = parentPath(normalizedPath);
 
     return EmptyStateWidget(
-      icon: isMissingFolder ? Icons.folder_off_outlined : Icons.error_outline,
-      headline: isMissingFolder ? 'Folder not found' : 'Unable to open folder',
-      subtext: isMissingFolder
+      icon: isUnauthorized
+          ? Icons.lock_outline
+          : isMissingFolder
+          ? Icons.folder_off_outlined
+          : Icons.error_outline,
+      headline: isUnauthorized
+          ? 'Access denied'
+          : isMissingFolder
+          ? 'Folder not found'
+          : 'Unable to open folder',
+      subtext: isUnauthorized
+          ? 'You do not have access to $routeLabel. Retry, move up a level, or return to /cirrus.'
+          : isMissingFolder
           ? 'The folder at $routeLabel is unavailable. Retry, move up a level, or return to /cirrus.'
           : 'Cirrus could not load $routeLabel. Retry, move up a level, or return to /cirrus.',
       action: Wrap(
@@ -1570,6 +1615,9 @@ class _FileBrowserPageState extends State<FileBrowserPage>
                           onNavigateToFolder: _navigateToFolder,
                           currentPath: _currentPath,
                           errorBuilder: _buildFolderRouteErrorState,
+                          loadingBuilder: _currentPath.isNotEmpty
+                              ? _buildFolderResolutionLoadingShell
+                              : null,
                           onDropToFolder: _handleDropToFolder,
                           onFolderDragEnter: _handleFolderDragEnter,
                           onFolderDragExit: _handleFolderDragExit,

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -41,6 +41,7 @@ class FileBrowserView extends StatefulWidget {
     this.inArchive = false,
     this.isInitialLoad = false,
     this.errorBuilder,
+    this.loadingBuilder,
     super.key,
   });
 
@@ -73,6 +74,7 @@ class FileBrowserView extends StatefulWidget {
   /// a spinner.
   final bool isInitialLoad;
   final Widget Function(BuildContext context, Object error)? errorBuilder;
+  final WidgetBuilder? loadingBuilder;
 
   @override
   State<FileBrowserView> createState() => _FileBrowserViewState();
@@ -360,6 +362,9 @@ class _FileBrowserViewState extends State<FileBrowserView> {
         if (widget.isInitialLoad ||
             (snapshot.connectionState == ConnectionState.waiting &&
                 !snapshot.hasData)) {
+          if (widget.loadingBuilder != null) {
+            return widget.loadingBuilder!(context);
+          }
           return const Center(child: CircularProgressIndicator());
         }
 

--- a/test/widgets/file_browser_view_test.dart
+++ b/test/widgets/file_browser_view_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:autobutler/models/cirrus_file_node.dart';
+import 'package:autobutler/widgets/file_browser/file_browser_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> pumpFileBrowserView(
+    WidgetTester tester, {
+    required Future<List<CirrusFileNode>> filesFuture,
+    bool isInitialLoad = false,
+    Widget Function(BuildContext context, Object error)? errorBuilder,
+    WidgetBuilder? loadingBuilder,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FileBrowserView(
+            filesFuture: filesFuture,
+            isInitialLoad: isInitialLoad,
+            currentPath: '/Documents',
+            onFileMenuAction: (_, __) async {},
+            onOpenDirectory: (_) {},
+            isGridView: false,
+            errorBuilder: errorBuilder,
+            loadingBuilder: loadingBuilder,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('uses the custom loading builder during initial loads', (
+    WidgetTester tester,
+  ) async {
+    await pumpFileBrowserView(
+      tester,
+      filesFuture: Future.value(const <CirrusFileNode>[]),
+      isInitialLoad: true,
+      loadingBuilder: (_) => const Text('Opening /cirrus/Documents'),
+    );
+
+    expect(find.text('Opening /cirrus/Documents'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('uses the custom error builder for failed folder loads', (
+    WidgetTester tester,
+  ) async {
+    final completer = Completer<List<CirrusFileNode>>();
+    await pumpFileBrowserView(
+      tester,
+      filesFuture: completer.future,
+      errorBuilder: (_, error) => Text('Route error: $error'),
+    );
+    completer.completeError(Exception('folder not found'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Route error: Exception: folder not found'),
+      findsOneWidget,
+    );
+    expect(find.text('Unable to load files'), findsNothing);
+  });
+}

--- a/test/widgets/file_browser_view_test.dart
+++ b/test/widgets/file_browser_view_test.dart
@@ -20,7 +20,7 @@ void main() {
             filesFuture: filesFuture,
             isInitialLoad: isInitialLoad,
             currentPath: '/Documents',
-            onFileMenuAction: (_, __) async {},
+            onFileMenuAction: (_, _) async {},
             onOpenDirectory: (_) {},
             isGridView: false,
             errorBuilder: errorBuilder,


### PR DESCRIPTION
## Summary
- replace the startup folder spinner with a lightweight loading shell that shows the requested Cirrus path
- separate missing-folder and access-denied route states while preserving retry, parent, and root recovery actions
- add widget coverage for the custom loading and error builders used by Cirrus route states

Closes #1048
