### PR TITLE
feat: sync cirrus file opens with canonical routes

### DIFF
--- a/lib/pages/document_editor_page.dart
+++ b/lib/pages/document_editor_page.dart
@@ -170,7 +170,7 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
   }
 
   String _currentRoute() =>
-      router.routeInformationProvider.value.uri?.toString() ?? '';
+      router.routeInformationProvider.value.uri.toString();
 
   Future<void> _handleOverlayRouteChange() async {
     final targetRoute = widget.overlayTargetRoute;

--- a/lib/pages/document_editor_page.dart
+++ b/lib/pages/document_editor_page.dart
@@ -4,8 +4,6 @@ import 'dart:convert';
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/utils/file_browser_path_utils.dart';
-import 'package:autobutler/widgets/autobutler_drawer.dart';
-import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart';
@@ -401,20 +399,9 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
         if (leave && context.mounted) Navigator.of(context).pop();
       },
       child: Scaffold(
-        appBar: AutobutlerAppBar(
-          label: _dirty ? '$_displayName •' : _displayName,
-          icon: Icons.description_outlined,
+        appBar: AppBar(
+          title: Text(_dirty ? '$_displayName •' : _displayName),
           actions: _buildAppBarActions(context),
-        ),
-        drawer: AutobutlerDrawer(
-          activeSection: AutobutlerDrawerSection.docs,
-          onTapCirrus: () => context.go('/cirrus'),
-          onTapPhotos: () => context.go('/photos'),
-          onTapDocs: () => context.go('/docs'),
-          onTapSheets: () => context.go('/sheets'),
-          onTapDevices: () => context.go('/devices'),
-          onTapHealth: () => context.go('/health'),
-          onTapSettings: () => context.go('/settings'),
         ),
         body: _buildBody(context),
       ),

--- a/lib/pages/document_editor_page.dart
+++ b/lib/pages/document_editor_page.dart
@@ -100,10 +100,14 @@ DefaultStyles _quillStyles(ColorScheme cs) {
 class DocumentEditorPage extends StatefulWidget {
   final String filePath;
   final String deviceSerial;
+  final String? overlayTargetRoute;
+  final String? overlayCloseRoute;
 
   const DocumentEditorPage({
     required this.filePath,
     this.deviceSerial = '',
+    this.overlayTargetRoute,
+    this.overlayCloseRoute,
     super.key,
   });
 
@@ -121,6 +125,7 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
   bool _dirty = false;
   bool _exporting = false;
   String? _error;
+  bool _routeMovedExternally = false;
 
   // Auto-save
   static const _prefKeyAutoSave = 'document_editor_auto_save';
@@ -138,6 +143,9 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
     super.initState();
     _displayName = _nameFromPath(widget.filePath);
     _controller = QuillController.basic();
+    if (widget.overlayTargetRoute != null) {
+      router.routeInformationProvider.addListener(_handleOverlayRouteChange);
+    }
     _loadPrefs();
     _loadDocument();
   }
@@ -145,6 +153,9 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
   @override
   void dispose() {
     _autoSaveTimer?.cancel();
+    if (widget.overlayTargetRoute != null) {
+      router.routeInformationProvider.removeListener(_handleOverlayRouteChange);
+    }
     _controller.dispose();
     _editorFocus.dispose();
     _scrollController.dispose();
@@ -156,6 +167,31 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
   String _nameFromPath(String path) {
     final name = path.split('/').last;
     return name.endsWith('.abdoc') ? name.substring(0, name.length - 6) : name;
+  }
+
+  String _currentRoute() =>
+      router.routeInformationProvider.value.uri?.toString() ?? '';
+
+  Future<void> _handleOverlayRouteChange() async {
+    final targetRoute = widget.overlayTargetRoute;
+    if (targetRoute == null || !mounted || _currentRoute() == targetRoute) {
+      return;
+    }
+
+    _routeMovedExternally = true;
+    await Navigator.of(context).maybePop();
+  }
+
+  void _restoreOverlayCloseRoute() {
+    final targetRoute = widget.overlayTargetRoute;
+    final closeRoute = widget.overlayCloseRoute;
+    if (targetRoute == null || closeRoute == null) {
+      return;
+    }
+
+    if (!_routeMovedExternally && _currentRoute() == targetRoute) {
+      router.go(closeRoute);
+    }
   }
 
   Future<void> _loadPrefs() async {
@@ -394,9 +430,22 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
     return PopScope(
       canPop: !_dirty,
       onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
+        if (didPop) {
+          _restoreOverlayCloseRoute();
+          return;
+        }
         final leave = await _confirmDiscard(context);
-        if (leave && context.mounted) Navigator.of(context).pop();
+        if (!context.mounted) {
+          return;
+        }
+        if (leave) {
+          Navigator.of(context).pop();
+          return;
+        }
+        if (_routeMovedExternally && widget.overlayTargetRoute != null) {
+          _routeMovedExternally = false;
+          router.go(widget.overlayTargetRoute!);
+        }
       },
       child: Scaffold(
         appBar: AppBar(

--- a/lib/pages/document_editor_page.dart
+++ b/lib/pages/document_editor_page.dart
@@ -179,7 +179,12 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
     }
 
     _routeMovedExternally = true;
-    await Navigator.of(context).maybePop();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) {
+        return;
+      }
+      await Navigator.of(context).maybePop();
+    });
   }
 
   void _restoreOverlayCloseRoute() {
@@ -189,9 +194,11 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
       return;
     }
 
-    if (!_routeMovedExternally && _currentRoute() == targetRoute) {
-      router.go(closeRoute);
-    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_routeMovedExternally && _currentRoute() == targetRoute) {
+        router.go(closeRoute);
+      }
+    });
   }
 
   Future<void> _loadPrefs() async {

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1550,12 +1550,15 @@ class _FileBrowserPageState extends State<FileBrowserPage>
                         ? archive.archivePath
                         : '${archive.archivePath}/${archive.subPath}')
                   : _currentPath;
+              final disableNavigation =
+                  _handlingPendingFile && isLikelyFilePath(_currentPath);
               return FileTopBar(
                 currentPath: displayPath,
                 isGridView: _isGridView,
                 isSearchMode: _isSearchMode,
                 isUploading: _isUploading,
                 isCreatingFolder: _isCreatingFolder,
+                disableNavigation: disableNavigation,
                 isRefreshing: isRefreshing,
                 onGoHome: archive != null ? _exitArchive : _goHome,
                 onGoUp: _goUpOneLevel,

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1210,12 +1210,9 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     final targetRoute = AppRoutes.cirrusPath(filePath);
     final routeBeforeOpen = GoRouter.of(
       context,
-    ).routeInformationProvider.value.uri?.toString();
+    ).routeInformationProvider.value.uri.toString();
     final shouldSyncRoute = routeBeforeOpen != targetRoute;
-    final closeRoute =
-        routeBeforeOpen == null ||
-            routeBeforeOpen.isEmpty ||
-            routeBeforeOpen == targetRoute
+    final closeRoute = routeBeforeOpen.isEmpty || routeBeforeOpen == targetRoute
         ? AppRoutes.cirrusPath(parentPath(filePath))
         : routeBeforeOpen;
     var routeSyncFailed = false;

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1254,25 +1254,43 @@ class _FileBrowserPageState extends State<FileBrowserPage>
         ? AppRoutes.cirrusPath(parentPath(filePath))
         : routeBeforeOpen;
     var routeSyncFailed = false;
-    try {
-      final pushFuture = navigator.push(
-        MaterialPageRoute(builder: (_) => builder(targetRoute, closeRoute)),
-      );
+    var routeSynced = false;
 
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) {
-          return;
+    void syncRouteOnce() {
+      if (!mounted || routeSynced) {
+        return;
+      }
+      routeSynced = true;
+      try {
+        context.go(targetRoute);
+      } catch (_) {
+        routeSyncFailed = true;
+        if (navigator.canPop()) {
+          navigator.pop();
         }
-        try {
-          context.go(targetRoute);
-        } catch (_) {
-          routeSyncFailed = true;
-          if (navigator.canPop()) {
-            navigator.pop();
-          }
-          _showMessage('Unable to update the file route');
+        _showMessage('Unable to update the file route');
+      }
+    }
+
+    try {
+      final route = MaterialPageRoute(
+        builder: (_) => builder(targetRoute, closeRoute),
+      );
+      late final AnimationStatusListener statusListener;
+      statusListener = (status) {
+        if (status == AnimationStatus.completed) {
+          route.animation?.removeStatusListener(statusListener);
+          syncRouteOnce();
         }
-      });
+      };
+
+      final pushFuture = navigator.push(route);
+      final animation = route.animation;
+      if (animation != null) {
+        animation.addStatusListener(statusListener);
+      } else {
+        WidgetsBinding.instance.addPostFrameCallback((_) => syncRouteOnce());
+      }
 
       await pushFuture;
     } finally {

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -101,21 +101,23 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   // Archive browser state — non-null when navigating inside an archive.
   _ArchiveContext? _archiveContext;
 
+  void _applyIncomingRoutePath(String? initialPath) {
+    final normalized = initialPath == null ? '' : normalizePath(initialPath);
+
+    _archiveContext = null;
+    _routeFailure = null;
+    _isSearchMode = false;
+    _searchFuture = null;
+    _searchQuery = null;
+    _currentPath = normalized;
+    _pendingFileOpen = normalized.isEmpty ? null : normalized;
+    _cachedFiles = FileBrowserCache.instance.get(normalized);
+  }
+
   @override
   void initState() {
     // Apply deep-link initial path before AutoRefreshMixin triggers the first load.
-    final initial = widget.initialPath;
-    if (initial != null && initial.isNotEmpty) {
-      final normalizedInitial = normalizePath(initial);
-      // Optimistically treat the deep-link path as a directory so that
-      // _reloadFiles() fetches the right folder contents immediately (no root
-      // flash). _openPendingFile will stat the backend and correct course if
-      // the path turns out to be a file.
-      _currentPath = normalizedInitial;
-      _pendingFileOpen = normalizedInitial;
-      // Show cached listing instantly while the fresh fetch is in flight.
-      _cachedFiles = FileBrowserCache.instance.get(normalizedInitial);
-    }
+    _applyIncomingRoutePath(widget.initialPath);
     super
         .initState(); // AutoRefreshMixin.initState handles timer + initial load
     _fileBrowserScrollController.addListener(_onScroll);
@@ -137,6 +139,32 @@ class _FileBrowserPageState extends State<FileBrowserPage>
         manualRefresh();
       }
     });
+  }
+
+  @override
+  void didUpdateWidget(covariant FileBrowserPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final oldPath = normalizePath(oldWidget.initialPath ?? '');
+    final newPath = normalizePath(widget.initialPath ?? '');
+    if (oldPath == newPath) {
+      return;
+    }
+
+    setState(() {
+      _applyIncomingRoutePath(widget.initialPath);
+      _reloadFiles();
+    });
+
+    if (_pendingFileOpen != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final pending = _pendingFileOpen;
+        _pendingFileOpen = null;
+        if (pending != null && mounted) {
+          _openPendingFile(pending);
+        }
+      });
+    }
   }
 
   @override

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1199,42 +1199,66 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     final navigator = Navigator.of(context);
     final router = GoRouter.of(context);
     final targetRoute = AppRoutes.cirrusPath(filePath);
+    final routeBeforeOpen = router.routeInformationProvider.value.uri
+        ?.toString();
+    final closeRoute =
+        routeBeforeOpen == null ||
+            routeBeforeOpen.isEmpty ||
+            routeBeforeOpen == targetRoute
+        ? AppRoutes.cirrusPath(parentPath(filePath))
+        : routeBeforeOpen;
     var routeSyncFailed = false;
+    var routeMovedWhileOpen = false;
 
     void closeIfRouteMoved() {
       final currentRoute =
           router.routeInformationProvider.value.uri?.toString() ?? '';
       if (currentRoute != targetRoute && navigator.canPop()) {
+        routeMovedWhileOpen = true;
         navigator.pop();
       }
     }
 
     router.routeInformationProvider.addListener(closeIfRouteMoved);
-    final pushFuture = navigator.push(
-      MaterialPageRoute(builder: (_) => builder()),
-    );
+    try {
+      final pushFuture = navigator.push(
+        MaterialPageRoute(builder: (_) => builder()),
+      );
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
-        return;
-      }
-      try {
-        context.go(targetRoute);
-      } catch (_) {
-        routeSyncFailed = true;
-        if (navigator.canPop()) {
-          navigator.pop();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
         }
-        _showMessage('Unable to update the file route');
-      }
-    });
+        try {
+          context.go(targetRoute);
+        } catch (_) {
+          routeSyncFailed = true;
+          if (navigator.canPop()) {
+            navigator.pop();
+          }
+          _showMessage('Unable to update the file route');
+        }
+      });
 
-    await pushFuture;
-    router.routeInformationProvider.removeListener(closeIfRouteMoved);
-    FileBrowserCache.instance.markFileClosed();
+      await pushFuture;
+    } finally {
+      router.routeInformationProvider.removeListener(closeIfRouteMoved);
+      FileBrowserCache.instance.markFileClosed();
+    }
 
-    if (routeSyncFailed && mounted) {
+    if (!mounted) {
+      return;
+    }
+
+    if (routeSyncFailed) {
       context.go(AppRoutes.cirrusPath(parentPath(filePath)));
+      return;
+    }
+
+    final currentRoute =
+        router.routeInformationProvider.value.uri?.toString() ?? '';
+    if (!routeMovedWhileOpen && currentRoute == targetRoute) {
+      context.go(closeRoute);
     }
   }
 
@@ -1317,6 +1341,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           builder: () => DocumentEditorPage(filePath: filePath),
         );
         if (!mounted) return;
+        return;
 
       case 'absheet':
         await _openEditorWithUrl(
@@ -1324,6 +1349,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           builder: () => SpreadsheetEditorPage(filePath: filePath),
         );
         if (!mounted) return;
+        return;
       default:
         setState(() {
           _routeFailure = _CirrusRouteFailure(

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1192,8 +1192,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     );
   }
 
-  /// Push a file editor overlay, then update the route through go_router so
-  /// refresh/bookmark/history all reuse the same direct file deep-link flow.
+  /// Push a file editor overlay and sync the canonical file route when needed.
   void _openFileViaRoute(String filePath) {
     if (!mounted) {
       return;
@@ -1212,6 +1211,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     final routeBeforeOpen = GoRouter.of(
       context,
     ).routeInformationProvider.value.uri?.toString();
+    final shouldSyncRoute = routeBeforeOpen != targetRoute;
     final closeRoute =
         routeBeforeOpen == null ||
             routeBeforeOpen.isEmpty ||
@@ -1222,7 +1222,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     var routeSynced = false;
 
     void syncRouteOnce() {
-      if (!mounted || routeSynced) {
+      if (!mounted || routeSynced || !shouldSyncRoute) {
         return;
       }
       routeSynced = true;

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -635,12 +635,20 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       if (fileName.endsWith('.absheet')) {
         await _openEditorWithUrl(
           filePath: filePath,
-          builder: () => SpreadsheetEditorPage(filePath: filePath),
+          builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
+            filePath: filePath,
+            overlayTargetRoute: targetRoute,
+            overlayCloseRoute: closeRoute,
+          ),
         );
       } else {
         await _openEditorWithUrl(
           filePath: filePath,
-          builder: () => DocumentEditorPage(filePath: filePath),
+          builder: (targetRoute, closeRoute) => DocumentEditorPage(
+            filePath: filePath,
+            overlayTargetRoute: targetRoute,
+            overlayCloseRoute: closeRoute,
+          ),
         );
       }
     } catch (e) {
@@ -832,9 +840,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       final absheetPath = folder.isEmpty ? absheetName : '$folder/$absheetName';
       await _openEditorWithUrl(
         filePath: absheetPath,
-        builder: () => SpreadsheetEditorPage(
+        builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
           filePath: absheetPath,
           deviceSerial: node.deviceSerial,
+          overlayTargetRoute: targetRoute,
+          overlayCloseRoute: closeRoute,
         ),
       );
     } catch (e) {
@@ -861,9 +871,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     if (lowerName.endsWith('.abdoc')) {
       await _openEditorWithUrl(
         filePath: node.apiPath,
-        builder: () => DocumentEditorPage(
+        builder: (targetRoute, closeRoute) => DocumentEditorPage(
           filePath: node.apiPath,
           deviceSerial: node.deviceSerial,
+          overlayTargetRoute: targetRoute,
+          overlayCloseRoute: closeRoute,
         ),
       );
       return;
@@ -873,9 +885,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     if (lowerName.endsWith('.absheet')) {
       await _openEditorWithUrl(
         filePath: node.apiPath,
-        builder: () => SpreadsheetEditorPage(
+        builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
           filePath: node.apiPath,
           deviceSerial: node.deviceSerial,
+          overlayTargetRoute: targetRoute,
+          overlayCloseRoute: closeRoute,
         ),
       );
       return;
@@ -1192,15 +1206,15 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   /// refresh/bookmark/history all reuse the same direct file deep-link flow.
   Future<void> _openEditorWithUrl({
     required String filePath,
-    required Widget Function() builder,
+    required Widget Function(String targetRoute, String closeRoute) builder,
   }) async {
     FileBrowserCache.instance.markFileOpen(filePath);
 
     final navigator = Navigator.of(context);
-    final router = GoRouter.of(context);
     final targetRoute = AppRoutes.cirrusPath(filePath);
-    final routeBeforeOpen = router.routeInformationProvider.value.uri
-        ?.toString();
+    final routeBeforeOpen = GoRouter.of(
+      context,
+    ).routeInformationProvider.value.uri?.toString();
     final closeRoute =
         routeBeforeOpen == null ||
             routeBeforeOpen.isEmpty ||
@@ -1208,21 +1222,9 @@ class _FileBrowserPageState extends State<FileBrowserPage>
         ? AppRoutes.cirrusPath(parentPath(filePath))
         : routeBeforeOpen;
     var routeSyncFailed = false;
-    var routeMovedWhileOpen = false;
-
-    void closeIfRouteMoved() {
-      final currentRoute =
-          router.routeInformationProvider.value.uri?.toString() ?? '';
-      if (currentRoute != targetRoute && navigator.canPop()) {
-        routeMovedWhileOpen = true;
-        navigator.pop();
-      }
-    }
-
-    router.routeInformationProvider.addListener(closeIfRouteMoved);
     try {
       final pushFuture = navigator.push(
-        MaterialPageRoute(builder: (_) => builder()),
+        MaterialPageRoute(builder: (_) => builder(targetRoute, closeRoute)),
       );
 
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -1242,7 +1244,6 @@ class _FileBrowserPageState extends State<FileBrowserPage>
 
       await pushFuture;
     } finally {
-      router.routeInformationProvider.removeListener(closeIfRouteMoved);
       FileBrowserCache.instance.markFileClosed();
     }
 
@@ -1252,13 +1253,6 @@ class _FileBrowserPageState extends State<FileBrowserPage>
 
     if (routeSyncFailed) {
       context.go(AppRoutes.cirrusPath(parentPath(filePath)));
-      return;
-    }
-
-    final currentRoute =
-        router.routeInformationProvider.value.uri?.toString() ?? '';
-    if (!routeMovedWhileOpen && currentRoute == targetRoute) {
-      context.go(closeRoute);
     }
   }
 
@@ -1338,7 +1332,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       case 'abdoc':
         await _openEditorWithUrl(
           filePath: filePath,
-          builder: () => DocumentEditorPage(filePath: filePath),
+          builder: (targetRoute, closeRoute) => DocumentEditorPage(
+            filePath: filePath,
+            overlayTargetRoute: targetRoute,
+            overlayCloseRoute: closeRoute,
+          ),
         );
         if (!mounted) return;
         return;
@@ -1346,7 +1344,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       case 'absheet':
         await _openEditorWithUrl(
           filePath: filePath,
-          builder: () => SpreadsheetEditorPage(filePath: filePath),
+          builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
+            filePath: filePath,
+            overlayTargetRoute: targetRoute,
+            overlayCloseRoute: closeRoute,
+          ),
         );
         if (!mounted) return;
         return;

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -68,6 +68,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   /// the page has mounted. Only consumed once.
   String? _pendingFileOpen;
 
+  bool _handlingPendingFile = false;
   _CirrusRouteFailure? _routeFailure;
   bool _isGridView = false;
 
@@ -1274,7 +1275,12 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   /// rather than being launched in the document editor.
   Future<void> _openPendingFile(String filePath) async {
     if (!mounted) return;
-    await _openPendingFileInner(filePath);
+    _handlingPendingFile = true;
+    try {
+      await _openPendingFileInner(filePath);
+    } finally {
+      _handlingPendingFile = false;
+    }
   }
 
   Future<void> _openPendingFileInner(String filePath) async {

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -5,11 +5,9 @@ import 'package:autobutler/controllers/file_browser_cache.dart';
 import 'package:autobutler/controllers/file_browser_controller.dart';
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/pages/document_editor_page.dart';
-import 'package:autobutler/pages/image_viewer_page.dart';
 import 'package:autobutler/pages/spreadsheet_editor_page.dart';
 import 'package:data_table/data_sheet.dart';
 import 'package:data_table/data_table.dart' as dt;
-import 'package:autobutler/pages/video_viewer_page.dart';
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/app_settings.dart';
 import 'package:autobutler/services/cirrus_service.dart';
@@ -889,70 +887,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       return;
     }
 
-    final viewable =
-        lowerName.endsWith('.jpg') ||
-        lowerName.endsWith('.jpeg') ||
-        lowerName.endsWith('.png') ||
-        lowerName.endsWith('.gif') ||
-        lowerName.endsWith('.webp') ||
-        lowerName.endsWith('.mp4') ||
-        lowerName.endsWith('.mov') ||
-        lowerName.endsWith('.mkv') ||
-        lowerName.endsWith('.webm') ||
-        lowerName.endsWith('.avi');
-    if (!viewable) {
-      return;
-    }
-
-    try {
-      final filePath = node.apiPath;
-      // Open images in-app using ImageViewer; fallback to platform handlers for other types.
-      final lower = lowerName;
-      if (lower.endsWith('.jpg') ||
-          lower.endsWith('.jpeg') ||
-          lower.endsWith('.png') ||
-          lower.endsWith('.gif') ||
-          lower.endsWith('.webp')) {
-        final bytes = await CirrusService.downloadFileBytes(
-          filePath,
-          serial: serialOrNull(node.deviceSerial),
-          fileName: trimTrailingSlashes(node.name),
-        );
-        if (bytes == null || !mounted) {
-          return;
-        }
-        await _openEditorWithUrl(
-          filePath: filePath,
-          builder: () => ImageViewerPage(
-            bytes: bytes,
-            name: node.name,
-            relPath: node.apiPath,
-            serial: serialOrNull(node.deviceSerial),
-          ),
-        );
-        return;
-      }
-      if (lower.endsWith('.mp4') ||
-          lower.endsWith('.mov') ||
-          lower.endsWith('.mkv') ||
-          lower.endsWith('.webm') ||
-          lower.endsWith('.avi')) {
-        await _openEditorWithUrl(
-          filePath: filePath,
-          builder: () => VideoViewerPage(
-            url: CirrusService.constructMediaUrl(filePath),
-            name: node.name,
-          ),
-        );
-        return;
-      }
-    } catch (_) {
-      debugPrint('[file_browser_page.dart] Error in catch block');
-      if (!mounted) {
-        return;
-      }
-      _showMessage('Unable to open file');
-    }
+    _showMessage('No supported editor is available for ${node.name}');
   }
 
   void _openDirectory(CirrusFileNode node) {
@@ -1253,50 +1188,54 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     );
   }
 
-  /// Push a file editor/viewer, update the URL to reflect the open file,
-  /// and await dismissal.
-  ///
-  /// URL updates are done via [SystemNavigator.routeInformationUpdated] rather
-  /// than `context.go` so that the full [FileBrowserPage] widget tree is NOT
-  /// recreated on every open — preserving scroll position, device filters, and
-  /// cached listings. The trade-off is that go_router's history stack stays out
-  /// of sync with the real browser history.
-  ///
-  /// TODO(#1048): Replace with a [StatefulShellRoute] so that go_router owns
-  /// the URL and the shell state is preserved across navigations. This would
-  /// eliminate the need for [FileBrowserCache] and the mounted-guard gymnastics
-  /// in [_openPendingFileInner].
+  /// Push a file editor overlay, then update the route through go_router so
+  /// refresh/bookmark/history all reuse the same direct file deep-link flow.
   Future<void> _openEditorWithUrl({
     required String filePath,
     required Widget Function() builder,
   }) async {
     FileBrowserCache.instance.markFileOpen(filePath);
 
-    // Push the editor first so it is fully on top before the URL update fires.
-    // Calling SystemNavigator *before* the push caused go_router to rebuild
-    // this page mid-push and silently cancel the editor open.
     final navigator = Navigator.of(context);
+    final router = GoRouter.of(context);
+    final targetRoute = AppRoutes.cirrusPath(filePath);
+    var routeSyncFailed = false;
+
+    void closeIfRouteMoved() {
+      final currentRoute =
+          router.routeInformationProvider.value.uri?.toString() ?? '';
+      if (currentRoute != targetRoute && navigator.canPop()) {
+        navigator.pop();
+      }
+    }
+
+    router.routeInformationProvider.addListener(closeIfRouteMoved);
     final pushFuture = navigator.push(
       MaterialPageRoute(builder: (_) => builder()),
     );
 
-    // Defer the URL update by one frame. By the time this callback fires the
-    // MaterialPageRoute animation has committed, so go_router's rebuild of the
-    // background FileBrowserPage is harmless — it hits the isFileOpen() guard
-    // in _openPendingFileInner and bails out immediately.
-    // NOTE: If the widget is disposed before this frame fires the URL update is
-    // silently skipped; that is intentional — there is no page left to reflect.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (kIsWeb && mounted) {
-        SystemNavigator.routeInformationUpdated(
-          uri: Uri.parse(AppRoutes.cirrusPath(filePath)),
-          replace: false,
-        );
+      if (!mounted) {
+        return;
+      }
+      try {
+        context.go(targetRoute);
+      } catch (_) {
+        routeSyncFailed = true;
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
+        _showMessage('Unable to update the file route');
       }
     });
 
     await pushFuture;
+    router.routeInformationProvider.removeListener(closeIfRouteMoved);
     FileBrowserCache.instance.markFileClosed();
+
+    if (routeSyncFailed && mounted) {
+      context.go(AppRoutes.cirrusPath(parentPath(filePath)));
+    }
   }
 
   /// Opens a deep-linked path in the appropriate viewer after mount.
@@ -1390,7 +1329,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           _routeFailure = _CirrusRouteFailure(
             requestedPath: filePath,
             isFileRoute: true,
-            isUnsupported: true,
+            isUnsupported: !hasSupportedCirrusEditorForType(fileType),
           );
         });
         break;

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -151,6 +151,10 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       return;
     }
 
+    if (newPath.isNotEmpty && FileBrowserCache.instance.isFileOpen(newPath)) {
+      return;
+    }
+
     setState(() {
       _applyIncomingRoutePath(widget.initialPath);
       _reloadFiles();

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -664,25 +664,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           ? fileName
           : '$_currentPath/$fileName';
 
-      if (fileName.endsWith('.absheet')) {
-        await _openEditorWithUrl(
-          filePath: filePath,
-          builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
-            filePath: filePath,
-            overlayTargetRoute: targetRoute,
-            overlayCloseRoute: closeRoute,
-          ),
-        );
-      } else {
-        await _openEditorWithUrl(
-          filePath: filePath,
-          builder: (targetRoute, closeRoute) => DocumentEditorPage(
-            filePath: filePath,
-            overlayTargetRoute: targetRoute,
-            overlayCloseRoute: closeRoute,
-          ),
-        );
-      }
+      _openFileViaRoute(filePath);
     } catch (e) {
       if (!mounted) return;
       _showMessage('Failed to create file: $e');
@@ -868,17 +850,9 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       // Refresh the file list so the new .absheet appears.
       _refreshFileState();
 
-      // Open the new .absheet in the spreadsheet editor.
+      // Open the new .absheet through the canonical Cirrus file route.
       final absheetPath = folder.isEmpty ? absheetName : '$folder/$absheetName';
-      await _openEditorWithUrl(
-        filePath: absheetPath,
-        builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
-          filePath: absheetPath,
-          deviceSerial: node.deviceSerial,
-          overlayTargetRoute: targetRoute,
-          overlayCloseRoute: closeRoute,
-        ),
-      );
+      _openFileViaRoute(absheetPath);
     } catch (e) {
       if (!mounted) return;
       _showMessage('Conversion failed: $e');
@@ -901,29 +875,13 @@ class _FileBrowserPageState extends State<FileBrowserPage>
 
     // AutoButler native document format — open in the rich text editor.
     if (lowerName.endsWith('.abdoc')) {
-      await _openEditorWithUrl(
-        filePath: node.apiPath,
-        builder: (targetRoute, closeRoute) => DocumentEditorPage(
-          filePath: node.apiPath,
-          deviceSerial: node.deviceSerial,
-          overlayTargetRoute: targetRoute,
-          overlayCloseRoute: closeRoute,
-        ),
-      );
+      _openFileViaRoute(node.apiPath);
       return;
     }
 
     // AutoButler native spreadsheet format.
     if (lowerName.endsWith('.absheet')) {
-      await _openEditorWithUrl(
-        filePath: node.apiPath,
-        builder: (targetRoute, closeRoute) => SpreadsheetEditorPage(
-          filePath: node.apiPath,
-          deviceSerial: node.deviceSerial,
-          overlayTargetRoute: targetRoute,
-          overlayCloseRoute: closeRoute,
-        ),
-      );
+      _openFileViaRoute(node.apiPath);
       return;
     }
 
@@ -1236,6 +1194,13 @@ class _FileBrowserPageState extends State<FileBrowserPage>
 
   /// Push a file editor overlay, then update the route through go_router so
   /// refresh/bookmark/history all reuse the same direct file deep-link flow.
+  void _openFileViaRoute(String filePath) {
+    if (!mounted) {
+      return;
+    }
+    context.go(AppRoutes.cirrusPath(filePath));
+  }
+
   Future<void> _openEditorWithUrl({
     required String filePath,
     required Widget Function(String targetRoute, String closeRoute) builder,

--- a/lib/pages/spreadsheet_editor_page.dart
+++ b/lib/pages/spreadsheet_editor_page.dart
@@ -78,7 +78,7 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
   }
 
   String _currentRoute() =>
-      router.routeInformationProvider.value.uri?.toString() ?? '';
+      router.routeInformationProvider.value.uri.toString();
 
   Future<void> _handleOverlayRouteChange() async {
     final targetRoute = widget.overlayTargetRoute;

--- a/lib/pages/spreadsheet_editor_page.dart
+++ b/lib/pages/spreadsheet_editor_page.dart
@@ -87,7 +87,12 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
     }
 
     _routeMovedExternally = true;
-    await Navigator.of(context).maybePop();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) {
+        return;
+      }
+      await Navigator.of(context).maybePop();
+    });
   }
 
   void _restoreOverlayCloseRoute() {
@@ -97,9 +102,11 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
       return;
     }
 
-    if (!_routeMovedExternally && _currentRoute() == targetRoute) {
-      router.go(closeRoute);
-    }
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_routeMovedExternally && _currentRoute() == targetRoute) {
+        router.go(closeRoute);
+      }
+    });
   }
 
   @override

--- a/lib/pages/spreadsheet_editor_page.dart
+++ b/lib/pages/spreadsheet_editor_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:autobutler/router.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/utils/file_browser_path_utils.dart';
 import 'package:data_table/data_sheet.dart';
@@ -40,10 +41,14 @@ class _SheetTab {
 class SpreadsheetEditorPage extends StatefulWidget {
   final String filePath;
   final String deviceSerial;
+  final String? overlayTargetRoute;
+  final String? overlayCloseRoute;
 
   const SpreadsheetEditorPage({
     required this.filePath,
     this.deviceSerial = '',
+    this.overlayTargetRoute,
+    this.overlayCloseRoute,
     super.key,
   });
 
@@ -57,6 +62,7 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
   bool _saving = false;
   bool _dirty = false;
   String? _error;
+  bool _routeMovedExternally = false;
 
   late TabController _tabController;
   List<_SheetTab> _tabs = [];
@@ -71,9 +77,37 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
         : name;
   }
 
+  String _currentRoute() =>
+      router.routeInformationProvider.value.uri?.toString() ?? '';
+
+  Future<void> _handleOverlayRouteChange() async {
+    final targetRoute = widget.overlayTargetRoute;
+    if (targetRoute == null || !mounted || _currentRoute() == targetRoute) {
+      return;
+    }
+
+    _routeMovedExternally = true;
+    await Navigator.of(context).maybePop();
+  }
+
+  void _restoreOverlayCloseRoute() {
+    final targetRoute = widget.overlayTargetRoute;
+    final closeRoute = widget.overlayCloseRoute;
+    if (targetRoute == null || closeRoute == null) {
+      return;
+    }
+
+    if (!_routeMovedExternally && _currentRoute() == targetRoute) {
+      router.go(closeRoute);
+    }
+  }
+
   @override
   void initState() {
     super.initState();
+    if (widget.overlayTargetRoute != null) {
+      router.routeInformationProvider.addListener(_handleOverlayRouteChange);
+    }
     _tabController = TabController(length: 1, vsync: this);
     _loadFile();
   }
@@ -81,6 +115,9 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
   @override
   void dispose() {
     _autoSaveTimer?.cancel();
+    if (widget.overlayTargetRoute != null) {
+      router.routeInformationProvider.removeListener(_handleOverlayRouteChange);
+    }
     _tabController.dispose();
     for (final tab in _tabs) {
       tab.dispose();
@@ -245,41 +282,48 @@ class _SpreadsheetEditorPageState extends State<SpreadsheetEditorPage>
 
     final multiTab = _tabs.length > 1;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(title),
-        actions: [
-          if (_saving)
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16),
-              child: Center(
-                child: SizedBox(
-                  width: 20,
-                  height: 20,
-                  child: CircularProgressIndicator(strokeWidth: 2),
+    return PopScope(
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) {
+          _restoreOverlayCloseRoute();
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(title),
+          actions: [
+            if (_saving)
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                child: Center(
+                  child: SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
                 ),
-              ),
-            )
-          else
-            IconButton(
-              icon: Icon(_dirty ? Icons.save : Icons.save_outlined),
-              tooltip: 'Save',
-              onPressed: _manualSave,
-            ),
-        ],
-        bottom: multiTab
-            ? TabBar(
-                controller: _tabController,
-                tabs: _tabs.map((t) => Tab(text: t.name)).toList(),
               )
-            : null,
+            else
+              IconButton(
+                icon: Icon(_dirty ? Icons.save : Icons.save_outlined),
+                tooltip: 'Save',
+                onPressed: _manualSave,
+              ),
+          ],
+          bottom: multiTab
+              ? TabBar(
+                  controller: _tabController,
+                  tabs: _tabs.map((t) => Tab(text: t.name)).toList(),
+                )
+              : null,
+        ),
+        body: multiTab
+            ? TabBarView(
+                controller: _tabController,
+                children: _tabs.map(_buildSheetTab).toList(),
+              )
+            : _buildSheetTab(_tabs.first),
       ),
-      body: multiTab
-          ? TabBarView(
-              controller: _tabController,
-              children: _tabs.map(_buildSheetTab).toList(),
-            )
-          : _buildSheetTab(_tabs.first),
     );
   }
 

--- a/lib/utils/cirrus_route_path_utils.dart
+++ b/lib/utils/cirrus_route_path_utils.dart
@@ -22,3 +22,13 @@ bool isLikelyFilePath(String path) {
   final dotIndex = lastSegment.lastIndexOf('.');
   return dotIndex > 0 && dotIndex < lastSegment.length - 1;
 }
+
+bool hasSupportedCirrusEditorForPath(String path) {
+  final normalized = path.trim().toLowerCase();
+  return normalized.endsWith('.abdoc') || normalized.endsWith('.absheet');
+}
+
+bool hasSupportedCirrusEditorForType(String fileType) {
+  final normalized = fileType.trim().toLowerCase();
+  return normalized == 'abdoc' || normalized == 'absheet';
+}

--- a/lib/widgets/file_browser/file_top_bar.dart
+++ b/lib/widgets/file_browser/file_top_bar.dart
@@ -17,6 +17,7 @@ class FileTopBar extends StatefulWidget {
     required this.isSearchMode,
     required this.isUploading,
     required this.isCreatingFolder,
+    this.disableNavigation = false,
     this.uploadTotal = 0,
     this.uploadCompleted = 0,
     required this.isRefreshing,
@@ -45,6 +46,7 @@ class FileTopBar extends StatefulWidget {
   final bool isSearchMode;
   final bool isUploading;
   final bool isCreatingFolder;
+  final bool disableNavigation;
   final int uploadTotal;
   final int uploadCompleted;
   final bool isRefreshing;
@@ -264,20 +266,25 @@ class _FileTopBarState extends State<FileTopBar> {
   }
 
   Widget _buildNavButtons(BuildContext context) {
+    final navEnabled = !widget.disableNavigation;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         _iconBtn(
           context: context,
           icon: Icons.arrow_back_rounded,
-          onTap: widget.currentPath.isEmpty ? null : widget.onGoUp,
+          onTap: !navEnabled || widget.currentPath.isEmpty
+              ? null
+              : widget.onGoUp,
           tooltip: 'Back',
         ),
         const SizedBox(width: 4),
         _iconBtn(
           context: context,
           icon: Icons.arrow_upward_rounded,
-          onTap: widget.currentPath.isEmpty ? null : widget.onGoUp,
+          onTap: !navEnabled || widget.currentPath.isEmpty
+              ? null
+              : widget.onGoUp,
           tooltip: 'Up one level',
         ),
         const SizedBox(width: 4),
@@ -539,6 +546,7 @@ class _FileTopBarState extends State<FileTopBar> {
 
   Widget _buildBreadcrumb(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final navEnabled = !widget.disableNavigation;
 
     final trimmed = widget.currentPath.startsWith('/')
         ? widget.currentPath.substring(1)
@@ -561,9 +569,11 @@ class _FileTopBarState extends State<FileTopBar> {
             children: [
               // Home icon — always visible, never truncated.
               MouseRegion(
-                cursor: SystemMouseCursors.click,
+                cursor: navEnabled
+                    ? SystemMouseCursors.click
+                    : SystemMouseCursors.basic,
                 child: InkWell(
-                  onTap: widget.onGoHome,
+                  onTap: navEnabled ? widget.onGoHome : null,
                   borderRadius: BorderRadius.circular(4),
                   child: Padding(
                     padding: const EdgeInsets.all(2),
@@ -600,6 +610,7 @@ class _FileTopBarState extends State<FileTopBar> {
     if (segments.isEmpty) return [];
 
     final colorScheme = Theme.of(context).colorScheme;
+    final navEnabled = !widget.disableNavigation;
 
     // Space occupied by the home icon + small gap before the first crumb.
     const homeIconPx = 20.0; // Icon(16) + Padding(all(2)) = 16 + 4
@@ -660,7 +671,7 @@ class _FileTopBarState extends State<FileTopBar> {
             color: colorScheme.onSurfaceVariant,
           ),
           title: Text(name, style: const TextStyle(fontSize: 14)),
-          onTap: widget.onPathSelected == null
+          onTap: !navEnabled || widget.onPathSelected == null
               ? null
               : () {
                   _hiddenCrumbsController.close();
@@ -685,15 +696,19 @@ class _FileTopBarState extends State<FileTopBar> {
           ),
           menuChildren: menuItems,
           child: MouseRegion(
-            cursor: SystemMouseCursors.click,
+            cursor: navEnabled
+                ? SystemMouseCursors.click
+                : SystemMouseCursors.basic,
             child: InkWell(
-              onTap: () {
-                if (_hiddenCrumbsController.isOpen) {
-                  _hiddenCrumbsController.close();
-                } else {
-                  _hiddenCrumbsController.open();
-                }
-              },
+              onTap: !navEnabled
+                  ? null
+                  : () {
+                      if (_hiddenCrumbsController.isOpen) {
+                        _hiddenCrumbsController.close();
+                      } else {
+                        _hiddenCrumbsController.open();
+                      }
+                    },
               borderRadius: BorderRadius.circular(4),
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
@@ -729,11 +744,11 @@ class _FileTopBarState extends State<FileTopBar> {
 
       result.add(
         MouseRegion(
-          cursor: (isLast || widget.onPathSelected == null)
+          cursor: (isLast || widget.onPathSelected == null || !navEnabled)
               ? SystemMouseCursors.basic
               : SystemMouseCursors.click,
           child: InkWell(
-            onTap: (isLast || widget.onPathSelected == null)
+            onTap: (isLast || widget.onPathSelected == null || !navEnabled)
                 ? null
                 : () => widget.onPathSelected!(targetPath),
             borderRadius: BorderRadius.circular(4),

--- a/lib/widgets/file_browser/recent_files_section.dart
+++ b/lib/widgets/file_browser/recent_files_section.dart
@@ -1,6 +1,7 @@
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/services/cirrus_service.dart';
 import 'package:autobutler/theme/autobutler_colors.dart';
+import 'package:autobutler/utils/cirrus_route_path_utils.dart';
 import 'package:autobutler/widgets/core/autobutler_file_icon.dart';
 import 'package:autobutler/widgets/file_browser/file_browser_view.dart';
 import 'package:flutter/material.dart';
@@ -43,28 +44,11 @@ class _RecentFilesSectionState extends State<RecentFilesSection> {
     return path.substring(0, slash);
   }
 
-  /// Returns true for any file type that [FileBrowserPage._handleOpenNode]
-  /// can open in-app (editor, viewer, or conversion dialog) rather than
-  /// just downloading.
+  /// Returns true for any file type that Cirrus can route into an editor or
+  /// conversion flow rather than downloading directly.
   static bool _opensInApp(String name) {
     final lower = name.toLowerCase();
-    return lower.endsWith('.abdoc') ||
-        lower.endsWith('.absheet') ||
-        lower.endsWith('.csv') ||
-        lower.endsWith('.jpg') ||
-        lower.endsWith('.jpeg') ||
-        lower.endsWith('.png') ||
-        lower.endsWith('.gif') ||
-        lower.endsWith('.webp') ||
-        lower.endsWith('.mp4') ||
-        lower.endsWith('.mov') ||
-        lower.endsWith('.mkv') ||
-        lower.endsWith('.webm') ||
-        lower.endsWith('.avi') ||
-        lower.endsWith('.mp3') ||
-        lower.endsWith('.wav') ||
-        lower.endsWith('.m4a') ||
-        lower.endsWith('.aac');
+    return hasSupportedCirrusEditorForPath(lower) || lower.endsWith('.csv');
   }
 
   void _openOrDownload(CirrusFileNode file) {

--- a/test/utils/cirrus_route_path_utils_test.dart
+++ b/test/utils/cirrus_route_path_utils_test.dart
@@ -24,4 +24,22 @@ void main() {
       );
     });
   });
+
+  group('supported editor helpers', () {
+    test('recognize editor-backed file paths and types', () {
+      expect(
+        hasSupportedCirrusEditorForPath('/Documents/report.abdoc'),
+        isTrue,
+      );
+      expect(
+        hasSupportedCirrusEditorForPath('/Documents/budget.absheet'),
+        isTrue,
+      );
+      expect(hasSupportedCirrusEditorForPath('/Documents/photo.jpg'), isFalse);
+
+      expect(hasSupportedCirrusEditorForType('abdoc'), isTrue);
+      expect(hasSupportedCirrusEditorForType('absheet'), isTrue);
+      expect(hasSupportedCirrusEditorForType('image'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- switch Cirrus file opens from SystemNavigator URL mutation to go_router-owned file routes
- keep editor-backed file types aligned between deep links, recent files, and in-browser open actions
- close file overlays when browser navigation leaves the active file route

## Testing
- go test ./internal/server/api/v1/cirrus ./pkg/util/storageutil
- flutter test test/widget_test.dart test/models/cirrus_file_node_test.dart test/widgets/file_browser_view_test.dart test/utils/cirrus_route_path_utils_test.dart