### PR TITLE
docs: add Terms of Service and lint

### DIFF
--- a/TERMS_OF_SERVICE.md
+++ b/TERMS_OF_SERVICE.md
@@ -1,0 +1,133 @@
+# Terms of Service
+
+*Last updated: May 12, 2026*
+
+> **Plain talk first:** AutoButler is open-source software you run on your own hardware. We don't host your files, we don't have a subscription to cancel, and we're not interested in your data. These terms cover use of the website (**autobutler.org**), the software we publish, and any network coordination services we operate (such as the remote access infrastructure at **network.autobutler.org**).
+>
+> By downloading the software, using the website, or accessing any AutoButler services, you agree to these terms.
+
+## 1. Definitions
+
+**"AutoButler"**, **"we"**, **"our"**, or **"us"** refers to the AutoButler project and its maintainers.
+
+**"Software"** means the AutoButler application, its source code, binaries, libraries, documentation, and any associated tools published at [github.com/autobutler-org/autobutler](https://github.com/autobutler-org/autobutler).
+
+**"Services"** means any online infrastructure we operate to support the Software, including but not limited to the remote access coordination service at *network.autobutler.org* and the AutoButler website at *autobutler.org*.
+
+**"You"** or **"User"** means any person or entity that downloads, installs, runs, or accesses the Software or Services.
+
+## 2. The Software License
+
+AutoButler is released as open-source software. The specific rights granted to you — including rights to use, copy, modify, merge, publish, distribute, sublicense, and sell — are defined by the [LICENSE](LICENSE) file included in the repository. The license file is the authoritative and legally binding grant of rights for the Software.
+
+Nothing in these Terms supersedes, restricts, or expands the rights granted under the open-source license. These Terms govern use of the website and Services; the license governs use of the Software.
+
+## 3. Use of the Website
+
+Autobutler.org is an informational website. You are welcome to access it, link to it, and share content from it. You agree not to:
+
+- Use the website in any way that could damage, disable, or impair it or interfere with others' use of it;
+- Use automated tools to scrape, crawl, or extract data in a manner that places unreasonable load on our servers;
+- Represent or imply that AutoButler endorses your products, services, or views without our explicit written consent;
+- Attempt to gain unauthorized access to any portion of the website or its underlying systems.
+
+## 4. Network and Coordination Services
+
+AutoButler operates optional infrastructure to support remote access features in the Software (currently at *network.autobutler.org*). This infrastructure handles only **control plane traffic** — it facilitates encrypted peer-to-peer connections between your devices. It does not store, relay, proxy, or have access to your files or personal data.
+
+These Services are provided on a best-effort basis. We reserve the right to modify, suspend, or discontinue them at any time with reasonable notice where practicable. You can self-host equivalent infrastructure (e.g., Headscale) as documented in the repository if you prefer not to rely on our Services.
+
+You agree not to use the Services to:
+
+- Interfere with or disrupt other users' connections or the infrastructure itself;
+- Conduct denial-of-service attacks or transmit malicious code;
+- Circumvent any security measures we implement.
+
+We reserve the right to suspend or terminate access to the Services for any user who violates these terms or who abuses the infrastructure.
+
+## 5. Your Data and Privacy
+
+Because AutoButler runs on your own hardware, **we do not have access to the files you store using the Software**. Your data stays on your device, on your home network.
+
+When you interact with the website or coordination Services, we may collect limited technical data (such as IP addresses and request logs) for operational and security purposes. We do not sell this data or use it for advertising.
+
+For full details, see our [Privacy Policy](https://autobutler.org/privacy).
+
+## 6. Intellectual Property
+
+The AutoButler name, logo, and website content are the property of the AutoButler project. The Software is open-source; see Section 2 for your rights with respect to the code.
+
+You may not use the AutoButler name, logo, or branding in a way that suggests official endorsement or affiliation without our written permission. Nominative fair use for commentary, review, or identification purposes is permitted.
+
+## 7. Contributions
+
+If you contribute to AutoButler — whether code, bug reports, documentation, translations, or other materials — thank you. By submitting a contribution (including pull requests) you represent that:
+
+- You have the right to submit the contribution;
+- You agree that your contribution may be incorporated into the project under the project's existing open-source license;
+- You are not submitting contributions that knowingly introduce malicious code or security vulnerabilities.
+
+We reserve the right to accept, modify, or decline any contribution at our discretion.
+
+## 8. Disclaimer of Warranties
+
+**THE SOFTWARE AND SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.** To the fullest extent permitted by applicable law, we expressly disclaim all warranties, including but not limited to:
+
+- Implied warranties of merchantability, fitness for a particular purpose, and non-infringement;
+- Warranties that the Software or Services will be uninterrupted, error-free, or free of harmful components;
+- Warranties regarding the accuracy, reliability, or completeness of any content.
+
+You are running the Software on your own hardware. You are responsible for your own data and your own backups. **Back up your data.**
+
+## 9. Limitation of Liability
+
+To the fullest extent permitted by applicable law, in no event shall AutoButler, its maintainers, contributors, or affiliates be liable for any indirect, incidental, special, consequential, or punitive damages, including but not limited to:
+
+- Loss of data or data corruption;
+- Loss of profits or revenue;
+- Business interruption;
+- Costs of substitute goods, services, or technology;
+- Any other damages arising out of or related to your use of, or inability to use, the Software or Services.
+
+This limitation applies regardless of the theory of liability (contract, tort, negligence, strict liability, or otherwise) and even if we have been advised of the possibility of such damages.
+
+Some jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation may not apply to you in full.
+
+## 10. Indemnification
+
+You agree to indemnify, defend, and hold harmless AutoButler and its maintainers, contributors, and affiliates from and against any claims, damages, losses, liabilities, costs, and expenses (including reasonable legal fees) arising out of or related to:
+
+- Your use or misuse of the Software or Services;
+- Your violation of these Terms;
+- Your violation of any applicable law or regulation; or
+- Any content or data you process, store, or transmit using the Software.
+
+## 11. Third-Party Services and Links
+
+The Software may integrate with or reference third-party services (such as Tailscale, Headscale, or cloud storage providers). We are not responsible for the availability, reliability, or terms of third-party services. Your use of any third-party service is governed by that service's own terms and privacy policies.
+
+## 12. Governing Law and Disputes
+
+These Terms are governed by and construed in accordance with the laws of the State of Alaska, United States, without regard to its conflict of law provisions.
+
+Any dispute arising from or related to these Terms or your use of the Software or Services shall first be attempted to be resolved through good-faith discussion. If a dispute cannot be resolved informally, it shall be subject to the exclusive jurisdiction of the courts located in the State of Alaska.
+
+Nothing in this section prevents either party from seeking injunctive or other equitable relief in any court of competent jurisdiction where necessary to protect intellectual property rights or prevent imminent harm.
+
+## 13. Changes to These Terms
+
+We may update these Terms from time to time. When we do, we will update the "Last updated" date at the top of this page. Continued use of the Software or Services after a change constitutes acceptance of the updated Terms.
+
+We will not make changes that are materially harmful to users without providing reasonable advance notice. For significant changes, we will announce the update in the project's GitHub repository.
+
+## 14. Severability
+
+If any provision of these Terms is found to be unenforceable or invalid by a court of competent jurisdiction, that provision shall be limited or eliminated to the minimum extent necessary, and the remaining provisions shall continue in full force and effect.
+
+## 15. Entire Agreement
+
+These Terms, together with the open-source license governing the Software and our Privacy Policy, constitute the entire agreement between you and AutoButler regarding the subject matter herein and supersede all prior agreements and understandings relating to such subject matter.
+
+## Questions or Concerns?
+
+If something here is unclear or you have questions about these Terms, please open an issue on [GitHub](https://github.com/autobutler-org/autobutler) or reach out via [autobutler.org/contact](https://autobutler.org/contact).

--- a/packages/ab_formula/lib/evaluation/evaluator/builtins.dart
+++ b/packages/ab_formula/lib/evaluation/evaluator/builtins.dart
@@ -169,7 +169,8 @@ FormulaValue _power(List<ResolvedArgument> arguments) {
     return rightResult.error!;
   }
   return NumberValue(
-      math.pow(leftResult.value!, rightResult.value!).toDouble());
+    math.pow(leftResult.value!, rightResult.value!).toDouble(),
+  );
 }
 
 FormulaValue _sqrt(List<ResolvedArgument> arguments) {
@@ -277,10 +278,7 @@ FormulaValue _mid(List<ResolvedArgument> arguments) {
   final text = textResult.value!;
   final startIndex = math.max(0, startResult.value!.toInt() - 1);
   final endIndex = math
-      .min(
-        text.length,
-        startIndex + math.max(0, countResult.value!.toInt()),
-      )
+      .min(text.length, startIndex + math.max(0, countResult.value!.toInt()))
       .toInt();
   if (startIndex >= text.length) {
     return const StringValue('');
@@ -293,8 +291,12 @@ FormulaValue _find(List<ResolvedArgument> arguments) {
   if (needleResult.error != null) {
     return needleResult.error!;
   }
-  final haystackResult =
-      _expectStringArg(arguments, 1, minCount: 2, maxCount: 3);
+  final haystackResult = _expectStringArg(
+    arguments,
+    1,
+    minCount: 2,
+    maxCount: 3,
+  );
   if (haystackResult.error != null) {
     return haystackResult.error!;
   }
@@ -319,13 +321,21 @@ FormulaValue _substitute(List<ResolvedArgument> arguments) {
   if (textResult.error != null) {
     return textResult.error!;
   }
-  final oldTextResult =
-      _expectStringArg(arguments, 1, minCount: 3, maxCount: 4);
+  final oldTextResult = _expectStringArg(
+    arguments,
+    1,
+    minCount: 3,
+    maxCount: 4,
+  );
   if (oldTextResult.error != null) {
     return oldTextResult.error!;
   }
-  final newTextResult =
-      _expectStringArg(arguments, 2, minCount: 3, maxCount: 4);
+  final newTextResult = _expectStringArg(
+    arguments,
+    2,
+    minCount: 3,
+    maxCount: 4,
+  );
   if (newTextResult.error != null) {
     return newTextResult.error!;
   }
@@ -335,8 +345,12 @@ FormulaValue _substitute(List<ResolvedArgument> arguments) {
   if (arguments.length == 3) {
     return StringValue(text.replaceAll(oldText, newText));
   }
-  final instanceResult =
-      _expectNumberArg(arguments, 3, minCount: 3, maxCount: 4);
+  final instanceResult = _expectNumberArg(
+    arguments,
+    3,
+    minCount: 3,
+    maxCount: 4,
+  );
   if (instanceResult.error != null) {
     return instanceResult.error!;
   }

--- a/packages/ab_formula/lib/evaluation/evaluator/evaluator.dart
+++ b/packages/ab_formula/lib/evaluation/evaluator/evaluator.dart
@@ -42,8 +42,9 @@ class FormulaEvaluator {
       StringNode(:final value) => StringValue(value),
       BoolNode(:final value) => BoolValue(value),
       CellRefNode(:final ref) => _readCell(ref),
-      RangeNode() =>
-        valueError('Range values can only be consumed by functions'),
+      RangeNode() => valueError(
+          'Range values can only be consumed by functions',
+        ),
       UnaryNode() => _evaluateUnary(node),
       BinaryNode() => _evaluateBinary(node),
       CallNode() => _evaluateCall(node),
@@ -167,17 +168,15 @@ class FormulaEvaluator {
       return valueError('Unsupported comparison operands');
     }
 
-    return BoolValue(
-      switch (operatorKind) {
-        TokenKind.eqEq => comparison == 0,
-        TokenKind.neq => comparison != 0,
-        TokenKind.lt => comparison < 0,
-        TokenKind.lte => comparison <= 0,
-        TokenKind.gt => comparison > 0,
-        TokenKind.gte => comparison >= 0,
-        _ => false,
-      },
-    );
+    return BoolValue(switch (operatorKind) {
+      TokenKind.eqEq => comparison == 0,
+      TokenKind.neq => comparison != 0,
+      TokenKind.lt => comparison < 0,
+      TokenKind.lte => comparison <= 0,
+      TokenKind.gt => comparison > 0,
+      TokenKind.gte => comparison >= 0,
+      _ => false,
+    });
   }
 
   FormulaValue _readCell(String ref) {

--- a/packages/ab_formula/lib/evaluation/parser/ast.dart
+++ b/packages/ab_formula/lib/evaluation/parser/ast.dart
@@ -95,6 +95,7 @@ final class ParsedFormula {
     required this.hasRangeArgs,
   })  : cellRefs = List.unmodifiable(LinkedHashSet<String>.from(cellRefs)),
         rangeRefs = List.unmodifiable(LinkedHashSet<String>.from(rangeRefs)),
-        calledFunctions =
-            List.unmodifiable(LinkedHashSet<String>.from(calledFunctions));
+        calledFunctions = List.unmodifiable(
+          LinkedHashSet<String>.from(calledFunctions),
+        );
 }

--- a/packages/ab_formula/lib/evaluation/parser/parser.dart
+++ b/packages/ab_formula/lib/evaluation/parser/parser.dart
@@ -202,18 +202,25 @@ class FormulaParser {
     }
 
     if (_functionArgumentDepth == 0) {
-      _error('Range references are only allowed inside function arguments.',
-          _current.offset);
+      _error(
+        'Range references are only allowed inside function arguments.',
+        _current.offset,
+      );
     }
 
     _advance();
-    final end =
-        _expect(TokenKind.cellRef, 'Expected cell reference after ":".');
+    final end = _expect(
+      TokenKind.cellRef,
+      'Expected cell reference after ":".',
+    );
     final rangeRef = '${start.value}:${end.value}';
     _rangeRefs.add(rangeRef);
     _hasRangeArgs = true;
     return RangeNode(
-        startRef: start.value, endRef: end.value, offset: start.offset);
+      startRef: start.value,
+      endRef: end.value,
+      offset: start.offset,
+    );
   }
 
   FormulaNode _parseCall() {

--- a/packages/ab_formula/lib/evaluation/token.dart
+++ b/packages/ab_formula/lib/evaluation/token.dart
@@ -20,7 +20,7 @@ enum TokenKind {
   lparen,
   rparen,
   comma,
-  eof
+  eof,
 }
 
 class Token {

--- a/packages/ab_formula/test/evaluator/builtins_test.dart
+++ b/packages/ab_formula/test/evaluator/builtins_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('AVERAGE', () {
       expect(
         call('AVERAGE', [
-          range([const NumberValue(2), const NumberValue(4)])
+          range([const NumberValue(2), const NumberValue(4)]),
         ]),
         const NumberValue(3),
       );
@@ -34,7 +34,7 @@ void main() {
     test('MIN', () {
       expect(
         call('MIN', [
-          range([const NumberValue(2), const NumberValue(-1)])
+          range([const NumberValue(2), const NumberValue(-1)]),
         ]),
         const NumberValue(-1),
       );
@@ -43,7 +43,7 @@ void main() {
     test('MAX', () {
       expect(
         call('MAX', [
-          range([const NumberValue(2), const NumberValue(9)])
+          range([const NumberValue(2), const NumberValue(9)]),
         ]),
         const NumberValue(9),
       );
@@ -51,13 +51,17 @@ void main() {
 
     test('ABS', () {
       expect(
-          call('ABS', [scalar(const NumberValue(-3))]), const NumberValue(3));
+        call('ABS', [scalar(const NumberValue(-3))]),
+        const NumberValue(3),
+      );
     });
 
     test('ROUND', () {
       expect(
-        call('ROUND',
-            [scalar(const NumberValue(3.14159)), scalar(const NumberValue(2))]),
+        call('ROUND', [
+          scalar(const NumberValue(3.14159)),
+          scalar(const NumberValue(2)),
+        ]),
         const NumberValue(3.14),
       );
     });
@@ -78,16 +82,20 @@ void main() {
 
     test('MOD', () {
       expect(
-        call('MOD',
-            [scalar(const NumberValue(10)), scalar(const NumberValue(4))]),
+        call('MOD', [
+          scalar(const NumberValue(10)),
+          scalar(const NumberValue(4)),
+        ]),
         const NumberValue(2),
       );
     });
 
     test('POWER', () {
       expect(
-        call('POWER',
-            [scalar(const NumberValue(2)), scalar(const NumberValue(5))]),
+        call('POWER', [
+          scalar(const NumberValue(2)),
+          scalar(const NumberValue(5)),
+        ]),
         const NumberValue(32),
       );
     });
@@ -111,8 +119,10 @@ void main() {
     });
 
     test('LEN', () {
-      expect(call('LEN', [scalar(const StringValue('hello'))]),
-          const NumberValue(5));
+      expect(
+        call('LEN', [scalar(const StringValue('hello'))]),
+        const NumberValue(5),
+      );
     });
 
     test('UPPER', () {
@@ -138,16 +148,20 @@ void main() {
 
     test('LEFT', () {
       expect(
-        call('LEFT',
-            [scalar(const StringValue('hello')), scalar(const NumberValue(2))]),
+        call('LEFT', [
+          scalar(const StringValue('hello')),
+          scalar(const NumberValue(2)),
+        ]),
         const StringValue('he'),
       );
     });
 
     test('RIGHT', () {
       expect(
-        call('RIGHT',
-            [scalar(const StringValue('hello')), scalar(const NumberValue(2))]),
+        call('RIGHT', [
+          scalar(const StringValue('hello')),
+          scalar(const NumberValue(2)),
+        ]),
         const StringValue('lo'),
       );
     });
@@ -218,7 +232,9 @@ void main() {
 
     test('NOT', () {
       expect(
-          call('NOT', [scalar(const BoolValue(false))]), const BoolValue(true));
+        call('NOT', [scalar(const BoolValue(false))]),
+        const BoolValue(true),
+      );
     });
 
     test('IFERROR', () {
@@ -236,13 +252,17 @@ void main() {
     });
 
     test('ISNUMBER', () {
-      expect(call('ISNUMBER', [scalar(const NumberValue(1))]),
-          const BoolValue(true));
+      expect(
+        call('ISNUMBER', [scalar(const NumberValue(1))]),
+        const BoolValue(true),
+      );
     });
 
     test('ISTEXT', () {
-      expect(call('ISTEXT', [scalar(const StringValue('x'))]),
-          const BoolValue(true));
+      expect(
+        call('ISTEXT', [scalar(const StringValue('x'))]),
+        const BoolValue(true),
+      );
     });
 
     test('COUNT', () {

--- a/packages/ab_formula/test/evaluator/evaluator_test.dart
+++ b/packages/ab_formula/test/evaluator/evaluator_test.dart
@@ -3,20 +3,19 @@ import 'package:test/test.dart';
 
 void main() {
   group('FormulaEvaluator', () {
-    FormulaValue evaluateFormula(
-      String source, {
-      CellAccessor? accessor,
-    }) {
+    FormulaValue evaluateFormula(String source, {CellAccessor? accessor}) {
       final parsed = parseTokens(lex(source));
       return evaluate(parsed, accessor ?? (_, __) => blankValue);
     }
 
-    test('evaluates arithmetic with precedence and right-associative power',
-        () {
-      final value = evaluateFormula('=2 ^ 3 ^ 2 + 4 * 5 - 6 / 3');
+    test(
+      'evaluates arithmetic with precedence and right-associative power',
+      () {
+        final value = evaluateFormula('=2 ^ 3 ^ 2 + 4 * 5 - 6 / 3');
 
-      expect(value, const NumberValue(530));
-    });
+        expect(value, const NumberValue(530));
+      },
+    );
 
     test('resolves cell references through the accessor', () {
       final calls = <(int, int)>[];
@@ -89,15 +88,17 @@ void main() {
       expect(findValue, const NumberValue(4));
     });
 
-    test('returns a value error when a range is evaluated outside a function',
-        () {
-      final parsed = RangeNode(startRef: 'A1', endRef: 'A2', offset: 0);
-      final evaluator = FormulaEvaluator(cellAccessor: (_, __) => blankValue);
+    test(
+      'returns a value error when a range is evaluated outside a function',
+      () {
+        final parsed = RangeNode(startRef: 'A1', endRef: 'A2', offset: 0);
+        final evaluator = FormulaEvaluator(cellAccessor: (_, __) => blankValue);
 
-      expect(
-        evaluator.evaluate(parsed),
-        valueError('Range values can only be consumed by functions'),
-      );
-    });
+        expect(
+          evaluator.evaluate(parsed),
+          valueError('Range values can only be consumed by functions'),
+        );
+      },
+    );
   });
 }

--- a/packages/ab_formula/test/fuzz/formula_fuzz_test.dart
+++ b/packages/ab_formula/test/fuzz/formula_fuzz_test.dart
@@ -16,8 +16,11 @@ void main() {
         try {
           final tokens = lex(candidate).toList();
           expect(tokens, isNotEmpty, reason: 'candidate: $candidate');
-          expect(tokens.last.kind, TokenKind.eof,
-              reason: 'candidate: $candidate');
+          expect(
+            tokens.last.kind,
+            TokenKind.eof,
+            reason: 'candidate: $candidate',
+          );
           expect(
             tokens.map((token) => token.offset),
             orderedEquals([...tokens.map((token) => token.offset)]..sort()),
@@ -43,8 +46,9 @@ void main() {
           reason: 'formula: $formula',
         );
         expect(
-          parsed.cellRefs
-              .every((ref) => RegExp(r'^[A-Z]+[1-9][0-9]*$').hasMatch(ref)),
+          parsed.cellRefs.every(
+            (ref) => RegExp(r'^[A-Z]+[1-9][0-9]*$').hasMatch(ref),
+          ),
           isTrue,
           reason: 'formula: $formula',
         );
@@ -90,7 +94,10 @@ String _randomAsciiFormula(Random random, {required int maxLength}) {
 }
 
 String _generateExpression(
-    Random random, int depth, bool insideFunctionArgument) {
+  Random random,
+  int depth,
+  bool insideFunctionArgument,
+) {
   if (depth >= 3) {
     return _generateTerminal(random, insideFunctionArgument);
   }
@@ -140,8 +147,9 @@ String _generateTerminal(Random random, bool insideFunctionArgument) {
   ];
 
   if (insideFunctionArgument) {
-    choices
-        .add(() => '${_generateCellRef(random)}:${_generateCellRef(random)}');
+    choices.add(
+      () => '${_generateCellRef(random)}:${_generateCellRef(random)}',
+    );
   }
 
   return choices[random.nextInt(choices.length)]();

--- a/packages/ab_formula/test/interpreter/interpreter_test.dart
+++ b/packages/ab_formula/test/interpreter/interpreter_test.dart
@@ -20,10 +20,7 @@ void main() {
 
   group('DataSheetInterpreter – topological evaluation', () {
     test('evaluates independent formula cells', () {
-      final results = interpret(1, 2, {
-        (0, 0): '3',
-        (0, 1): '=A1 * 2',
-      });
+      final results = interpret(1, 2, {(0, 0): '3', (0, 1): '=A1 * 2'});
 
       expect(results[(0, 1)], const NumberValue(6));
     });
@@ -64,9 +61,7 @@ void main() {
     });
 
     test('formula referencing an empty cell treats it as blank', () {
-      final results = interpret(1, 2, {
-        (0, 1): '=A1',
-      });
+      final results = interpret(1, 2, {(0, 1): '=A1'});
 
       expect(results[(0, 1)], blankValue);
     });
@@ -77,18 +72,12 @@ void main() {
       // A1 = =A1
       final results = interpret(1, 1, {(0, 0): '=A1'});
 
-      expect(
-        results[(0, 0)],
-        const ErrorValue('#REF!', 'Circular reference'),
-      );
+      expect(results[(0, 0)], const ErrorValue('#REF!', 'Circular reference'));
     });
 
     test('two-cell mutual reference marks both cells as circular', () {
       // A1==B1, B1==A1
-      final results = interpret(1, 2, {
-        (0, 0): '=B1',
-        (0, 1): '=A1',
-      });
+      final results = interpret(1, 2, {(0, 0): '=B1', (0, 1): '=A1'});
 
       expect(results[(0, 0)], const ErrorValue('#REF!', 'Circular reference'));
       expect(results[(0, 1)], const ErrorValue('#REF!', 'Circular reference'));
@@ -107,19 +96,21 @@ void main() {
       expect(results[(0, 2)], const ErrorValue('#REF!', 'Circular reference'));
     });
 
-    test('cell outside the cycle that depends on a cycle member gets error',
-        () {
-      // A1==A1 (cycle), B1==A1 (depends on cycle)
-      final results = interpret(1, 2, {
-        (0, 0): '=A1',
-        (0, 1): '=A1 + 1',
-      });
+    test(
+      'cell outside the cycle that depends on a cycle member gets error',
+      () {
+        // A1==A1 (cycle), B1==A1 (depends on cycle)
+        final results = interpret(1, 2, {(0, 0): '=A1', (0, 1): '=A1 + 1'});
 
-      expect(results[(0, 0)], const ErrorValue('#REF!', 'Circular reference'));
-      // B1's result is an ErrorValue because the accessor returns the
-      // pre-assigned circular error for A1.
-      expect(results[(0, 1)], isA<ErrorValue>());
-    });
+        expect(
+          results[(0, 0)],
+          const ErrorValue('#REF!', 'Circular reference'),
+        );
+        // B1's result is an ErrorValue because the accessor returns the
+        // pre-assigned circular error for A1.
+        expect(results[(0, 1)], isA<ErrorValue>());
+      },
+    );
 
     test('acyclic cells coexist with a separate cycle in the same sheet', () {
       // A1==A1 (cycle), B1=2, C1==B1*3 (acyclic chain)

--- a/packages/ab_formula/test/interpreter/scc_test.dart
+++ b/packages/ab_formula/test/interpreter/scc_test.dart
@@ -39,11 +39,7 @@ void main() {
     });
 
     test('three-node cycle is fully detected', () {
-      final g = _graph([
-        ((0, 0), (0, 1)),
-        ((0, 1), (0, 2)),
-        ((0, 2), (0, 0)),
-      ]);
+      final g = _graph([((0, 0), (0, 1)), ((0, 1), (0, 2)), ((0, 2), (0, 0))]);
       expect(findCycleMembers(g), {(0, 0), (0, 1), (0, 2)});
     });
 

--- a/packages/ab_formula/test/interpreter/topological_sort_test.dart
+++ b/packages/ab_formula/test/interpreter/topological_sort_test.dart
@@ -51,11 +51,7 @@ void main() {
         (0, 0): <(int, int)>{},
         (0, 1): {(0, 0)},
       };
-      final result = kahnSort(
-        {(0, 0), (0, 1)},
-        deps,
-        excludedNodes: {(0, 0)},
-      );
+      final result = kahnSort({(0, 0), (0, 1)}, deps, excludedNodes: {(0, 0)});
       expect(result.order, [(0, 1)]);
       expect(result.remaining, isEmpty);
     });
@@ -74,7 +70,7 @@ void main() {
     test('edges to literal (non-formula) cells do not inflate in-degree', () {
       // (0,1) depends on (0,0), but (0,0) is not in the formula node set.
       final deps = {
-        (0, 1): {(0, 0)}
+        (0, 1): {(0, 0)},
       };
       final result = kahnSort({(0, 1)}, deps);
       expect(result.order, [(0, 1)]);

--- a/packages/ab_formula/test/lexer/lexer_helpers_test.dart
+++ b/packages/ab_formula/test/lexer/lexer_helpers_test.dart
@@ -73,13 +73,7 @@ void main() {
     test('scanner helpers throw parse errors for invalid input', () {
       expect(
         () => scanFormulaNumber('1e+', 0),
-        throwsA(
-          isA<LexError>().having(
-            (error) => error.offset,
-            'offset',
-            1,
-          ),
-        ),
+        throwsA(isA<LexError>().having((error) => error.offset, 'offset', 1)),
       );
 
       expect(
@@ -87,10 +81,7 @@ void main() {
         throwsA(isA<LexError>()),
       );
 
-      expect(
-        () => scanFormulaWord(r'$foo', 0),
-        throwsA(isA<LexError>()),
-      );
+      expect(() => scanFormulaWord(r'$foo', 0), throwsA(isA<LexError>()));
     });
   });
 }

--- a/packages/ab_formula/test/lexer/lexer_test.dart
+++ b/packages/ab_formula/test/lexer/lexer_test.dart
@@ -5,8 +5,9 @@ import 'package:test/test.dart';
 void main() {
   group('lex', () {
     test('tokenizes a representative formula and emits eof', () {
-      final tokens =
-          lex('=SUM(\$a\$1:B2, "he""llo", true, 1.25E+3) >= 5').toList();
+      final tokens = lex(
+        '=SUM(\$a\$1:B2, "he""llo", true, 1.25E+3) >= 5',
+      ).toList();
 
       expect(
         tokens,
@@ -63,7 +64,10 @@ void main() {
         () => lex('=').toList(),
         throwsA(
           isA<LexError>().having((error) => error.offset, 'offset', 0).having(
-              (error) => error.message, 'message', contains('Standalone =')),
+                (error) => error.message,
+                'message',
+                contains('Standalone ='),
+              ),
         ),
       );
 
@@ -71,7 +75,10 @@ void main() {
         () => lex('A1 = 2').toList(),
         throwsA(
           isA<LexError>().having((error) => error.offset, 'offset', 3).having(
-              (error) => error.message, 'message', contains('Standalone =')),
+                (error) => error.message,
+                'message',
+                contains('Standalone ='),
+              ),
         ),
       );
     });
@@ -81,9 +88,10 @@ void main() {
         () => lex(r'$foo').toList(),
         throwsA(
           isA<LexError>().having((error) => error.offset, 'offset', 0).having(
-              (error) => error.message,
-              'message',
-              contains('Invalid cell reference')),
+                (error) => error.message,
+                'message',
+                contains('Invalid cell reference'),
+              ),
         ),
       );
 
@@ -91,16 +99,18 @@ void main() {
         () => lex('"abc').toList(),
         throwsA(
           isA<LexError>().having((error) => error.offset, 'offset', 0).having(
-              (error) => error.message,
-              'message',
-              contains('Unterminated string')),
+                (error) => error.message,
+                'message',
+                contains('Unterminated string'),
+              ),
         ),
       );
     });
 
     test('tokenizes each operator and delimiter with exact offsets', () {
-      final tokens =
-          lex('A1:B2+3-4*5/6%7^8,(9)<=10<>11!=12==13<14>15>=16').toList();
+      final tokens = lex(
+        'A1:B2+3-4*5/6%7^8,(9)<=10<>11!=12==13<14>15>=16',
+      ).toList();
 
       expect(
         tokens,
@@ -177,18 +187,11 @@ void main() {
     });
 
     test('accepts empty formulas as eof-only streams', () {
-      expect(
-        lex('').toList(),
-        equals([
-          Token(kind: TokenKind.eof, offset: 0),
-        ]),
-      );
+      expect(lex('').toList(), equals([Token(kind: TokenKind.eof, offset: 0)]));
 
       expect(
         lex('   ').toList(),
-        equals([
-          Token(kind: TokenKind.eof, offset: 3),
-        ]),
+        equals([Token(kind: TokenKind.eof, offset: 3)]),
       );
     });
 

--- a/packages/ab_formula/test/parser/parser_test.dart
+++ b/packages/ab_formula/test/parser/parser_test.dart
@@ -108,15 +108,17 @@ void main() {
       expect(root.right, isA<NumberNode>());
     });
 
-    test('parses cell references and deduplicates metadata in encounter order',
-        () {
-      final parsed = parseTokens(lex('=SUM(A1, A1, B2, A1, B2) + A1'));
+    test(
+      'parses cell references and deduplicates metadata in encounter order',
+      () {
+        final parsed = parseTokens(lex('=SUM(A1, A1, B2, A1, B2) + A1'));
 
-      expect(parsed.calledFunctions, orderedEquals(['SUM']));
-      expect(parsed.cellRefs, orderedEquals(['A1', 'B2']));
-      expect(parsed.rangeRefs, isEmpty);
-      expect(parsed.hasRangeArgs, isFalse);
-    });
+        expect(parsed.calledFunctions, orderedEquals(['SUM']));
+        expect(parsed.cellRefs, orderedEquals(['A1', 'B2']));
+        expect(parsed.rangeRefs, isEmpty);
+        expect(parsed.hasRangeArgs, isFalse);
+      },
+    );
 
     test('parses nested function calls with range arguments', () {
       final parsed = parseTokens(lex('=IF(A1>0, SUM(B1:B3), MAX(C1:C3))'));

--- a/packages/ab_formula/test/token_edge_cases_test.dart
+++ b/packages/ab_formula/test/token_edge_cases_test.dart
@@ -4,19 +4,22 @@ import 'package:test/test.dart';
 void main() {
   group('Token edge cases', () {
     test(
-        'fromJson handles null kind by defaulting to eof, non-string kind throws',
-        () {
-      final jsonNullKind = {'kind': null, 'value': 'x'};
-      final tNull = Token.fromJson(jsonNullKind);
-      expect(tNull.kind, equals(TokenKind.eof));
-      expect(tNull.value, equals('x'));
-      expect(tNull.offset, equals(0));
+      'fromJson handles null kind by defaulting to eof, non-string kind throws',
+      () {
+        final jsonNullKind = {'kind': null, 'value': 'x'};
+        final tNull = Token.fromJson(jsonNullKind);
+        expect(tNull.kind, equals(TokenKind.eof));
+        expect(tNull.value, equals('x'));
+        expect(tNull.offset, equals(0));
 
-      final jsonNonStringKind = {'kind': 123, 'value': 'y'};
-      // The implementation casts kind to String?; a non-string value will cause a TypeError.
-      expect(
-          () => Token.fromJson(jsonNonStringKind), throwsA(isA<TypeError>()));
-    });
+        final jsonNonStringKind = {'kind': 123, 'value': 'y'};
+        // The implementation casts kind to String?; a non-string value will cause a TypeError.
+        expect(
+          () => Token.fromJson(jsonNonStringKind),
+          throwsA(isA<TypeError>()),
+        );
+      },
+    );
 
     test('fromJson treats unknown kind string as eof', () {
       final jsonUnknown = {'kind': 'UnknownKind', 'value': 'v'};
@@ -35,34 +38,36 @@ void main() {
     });
 
     test(
-        'asNumber parses valid numeric formats (including negatives and exponents)',
-        () {
-      final a = Token(kind: TokenKind.number, value: '-42.5');
-      expect(a.asNumber(), equals(-42.5));
+      'asNumber parses valid numeric formats (including negatives and exponents)',
+      () {
+        final a = Token(kind: TokenKind.number, value: '-42.5');
+        expect(a.asNumber(), equals(-42.5));
 
-      final b = Token(kind: TokenKind.number, value: '1E3');
-      expect(b.asNumber(), equals(1000));
+        final b = Token(kind: TokenKind.number, value: '1E3');
+        expect(b.asNumber(), equals(1000));
 
-      final c = Token(kind: TokenKind.number, value: '6.022e23');
-      final parsed = c.asNumber();
-      expect(parsed, isNotNull);
-      expect(parsed! > 1e23, isTrue);
-    });
+        final c = Token(kind: TokenKind.number, value: '6.022e23');
+        final parsed = c.asNumber();
+        expect(parsed, isNotNull);
+        expect(parsed! > 1e23, isTrue);
+      },
+    );
 
     test(
-        'very long string values are preserved and participate in equality/hashCode',
-        () {
-      final longValue = List.filled(10000, 'x').join();
-      final t1 = Token(kind: TokenKind.ident, value: longValue);
-      final t2 = Token(kind: TokenKind.ident, value: longValue);
+      'very long string values are preserved and participate in equality/hashCode',
+      () {
+        final longValue = List.filled(10000, 'x').join();
+        final t1 = Token(kind: TokenKind.ident, value: longValue);
+        final t2 = Token(kind: TokenKind.ident, value: longValue);
 
-      expect(t1, equals(t2));
-      expect(t1.hashCode, equals(t2.hashCode));
+        expect(t1, equals(t2));
+        expect(t1.hashCode, equals(t2.hashCode));
 
-      final json = t1.toJson();
-      expect((json['value'] as String).length, equals(longValue.length));
-      expect(json['offset'], equals(0));
-    });
+        final json = t1.toJson();
+        expect((json['value'] as String).length, equals(longValue.length));
+        expect(json['offset'], equals(0));
+      },
+    );
 
     test('toJson/fromJson round-trip works for boundary values', () {
       final hugeNum = '1.2345e308';

--- a/packages/ab_formula/test/token_test.dart
+++ b/packages/ab_formula/test/token_test.dart
@@ -49,20 +49,22 @@ void main() {
       );
     });
 
-    test('fromJson handles missing kind (defaults to eof) and missing value',
-        () {
-      final jsonMissingKind = {'value': 'x'};
-      final t = Token.fromJson(jsonMissingKind);
-      expect(t.kind, equals(TokenKind.eof));
-      expect(t.value, equals('x'));
-      expect(t.offset, equals(0));
+    test(
+      'fromJson handles missing kind (defaults to eof) and missing value',
+      () {
+        final jsonMissingKind = {'value': 'x'};
+        final t = Token.fromJson(jsonMissingKind);
+        expect(t.kind, equals(TokenKind.eof));
+        expect(t.value, equals('x'));
+        expect(t.offset, equals(0));
 
-      final jsonMissingValue = {'kind': 'string', 'offset': '9'};
-      final t2 = Token.fromJson(jsonMissingValue);
-      expect(t2.kind, equals(TokenKind.string));
-      expect(t2.value, equals(''));
-      expect(t2.offset, equals(9));
-    });
+        final jsonMissingValue = {'kind': 'string', 'offset': '9'};
+        final t2 = Token.fromJson(jsonMissingValue);
+        expect(t2.kind, equals(TokenKind.string));
+        expect(t2.value, equals(''));
+        expect(t2.offset, equals(9));
+      },
+    );
 
     test('fromJson ignores extra fields', () {
       final json = {


### PR DESCRIPTION
## Summary

- Adds `TERMS_OF_SERVICE.md` to the repo root — a markdown version of the ToS being added to autobutler.org in [autobutler.org#93](https://github.com/autobutler-org/autobutler.org/pull/93)
- Includes pre-existing `dart format` fixes for `packages/ab_formula/` (17 files, whitespace only — the pre-commit hook required these to pass)

## Test plan

- [ ] Verify `TERMS_OF_SERVICE.md` renders correctly on GitHub
- [ ] Confirm content matches the website version in autobutler.org#93