### PR TITLE
fix(#1137): zero derived keys after vault unlock

### DIFF
--- a/internal/server/api/v1/vault/change_password.go
+++ b/internal/server/api/v1/vault/change_password.go
@@ -126,6 +126,7 @@ var changePasswordRoute = serverutil.ApiRoute(
 		// Re-unlock with the new key.
 		sessionKey := vaultcrypto.DeriveKey(req.NewPassword, newSalt, currentParams)
 		deps.VaultSession().Unlock(sessionKey, time.Duration(config.AutoLockSeconds)*time.Second)
+		vaultcrypto.ZeroKey(sessionKey)
 
 		return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(gin.H{
 			"changed":     true,

--- a/internal/server/api/v1/vault/setup.go
+++ b/internal/server/api/v1/vault/setup.go
@@ -70,6 +70,7 @@ var setupVaultRoute = serverutil.ApiRoute(
 		// Auto-unlock after setup.
 		unlockKey := vaultcrypto.DeriveKey(req.MasterPassword, salt, params)
 		deps.VaultSession().Unlock(unlockKey, 300*time.Second)
+		vaultcrypto.ZeroKey(unlockKey)
 
 		return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(gin.H{
 			"initialized": true,

--- a/pkg/util/vaultcrypto/vaultcrypto.go
+++ b/pkg/util/vaultcrypto/vaultcrypto.go
@@ -25,6 +25,8 @@ var (
 
 // verificationPlaintext is the known string we encrypt during vault setup.
 // On unlock we decrypt the stored blob and compare to this value.
+// This is intentionally not secret — security comes from the AES-256-GCM
+// encryption, not from the plaintext being unknown.
 var verificationPlaintext = []byte("autobutler-vault-ok")
 
 // Argon2Params holds tunable parameters for Argon2id key derivation.


### PR DESCRIPTION
## Summary
- Zero `unlockKey` in `setup.go` after `Unlock()` copies it — prevents derived key material from lingering in heap memory
- Zero `sessionKey` in `change_password.go` after `Unlock()` — same issue
- Clarify `verificationPlaintext` comment to note it's intentionally not secret

## Context
Flagged by exo's security review on PR #1137. `VaultSession.Unlock()` copies the key internally, but the caller's local slice was never zeroed, leaving key material in heap memory until GC.

## Test plan
- [ ] Vault setup still works (auto-unlocks after setup)
- [ ] Password change still works (re-unlocks with new key)
- [ ] Existing vault crypto tests pass