### PR TITLE
fix(#1210): correct sudoers mount path for service install

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -72,7 +72,7 @@ func createServiceDataDir() error {
 }
 
 func installSudoersRule() error {
-	mountsDir := filepath.Join(serviceDataDir, "mounts")
+	mountsDir := filepath.Join(serviceDataDir, "data", "mounts")
 	content := fmt.Sprintf(
 		"%s ALL=(root) NOPASSWD: /bin/mount * %s/*, /bin/umount %s/*\n",
 		serviceUserName, mountsDir, mountsDir,


### PR DESCRIPTION
## Summary

- Fixes the sudoers rule written during `autobutler install` — it was missing the `data/` segment in the mount path, causing `sudo mount` to be denied for the `autobutler` service user on Raspberry Pi

## Root Cause

`installSudoersRule()` used `filepath.Join(serviceDataDir, "mounts")` → `/var/lib/autobutler/mounts`, but `GetMountsDir()` resolves to `/var/lib/autobutler/data/mounts`.

## Test plan

- [ ] Run `sudo ./autobutler install` on a fresh Raspberry Pi
- [ ] Verify `/etc/sudoers.d/autobutler` contains `/var/lib/autobutler/data/mounts/*`
- [ ] Mount a USB drive from the UI and confirm it succeeds

Fixes #1210