### PR TITLE
fix(#1215): clear snackbar queue before showing new message

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1019,9 +1019,9 @@ class _FileBrowserPageState extends State<FileBrowserPage>
   }
 
   void _showMessage(String message) {
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(message)));
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.clearSnackBars();
+    messenger.showSnackBar(SnackBar(content: Text(message)));
   }
 
   void _goHome() {


### PR DESCRIPTION
## Summary

- Clears existing snackbars before showing a new one in the file browser's `_showMessage` helper
- Prevents dozens of "no supported editor" messages from queuing up when rapidly clicking unsupported files

## What changed

One-line fix in `_showMessage()`: call `messenger.clearSnackBars()` before `showSnackBar()`.

## Test plan

- [ ] Click on an unsupported file type — snackbar appears
- [ ] Rapidly click 10+ unsupported files — only the latest snackbar shows, no queue buildup
- [ ] Other snackbar messages (upload, download, delete) still work normally

Fixes #1215