### PR TITLE
fix(#1179, #1180): handle empty file list in docs and sheets pages

### DIFF
--- a/lib/pages/docs_page.dart
+++ b/lib/pages/docs_page.dart
@@ -6,6 +6,7 @@ import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 
 class DocsPage extends StatefulWidget {
   const DocsPage({super.key});
@@ -78,6 +79,56 @@ class _DocsPageState extends State<DocsPage> with SafeSetStateMixin {
     _load();
   }
 
+  Future<void> _createNewDoc() async {
+    final nameController = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('New Document'),
+        content: TextField(
+          controller: nameController,
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Document name',
+            border: OutlineInputBorder(),
+          ),
+          onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, nameController.text.trim()),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+    if (name == null || name.isEmpty || !mounted) return;
+
+    try {
+      final fileName = name.endsWith('.abdoc') ? name : '$name.abdoc';
+      final bytes = '{"ops":[{"insert":"\\n"}]}'.codeUnits;
+      final file = http.MultipartFile.fromBytes(
+        'files',
+        bytes,
+        filename: fileName,
+      );
+      await CirrusService.uploadFilesFromFormData('', [file]);
+      if (!mounted) return;
+      context.push(AppRoutes.docFile(fileName));
+      _load();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to create doc: $e')));
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -87,6 +138,11 @@ class _DocsPageState extends State<DocsPage> with SafeSetStateMixin {
         label: 'Docs',
         icon: Icons.description_outlined,
         actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'New document',
+            onPressed: _createNewDoc,
+          ),
           IconButton(
             icon: const Icon(Icons.refresh_rounded),
             tooltip: 'Reload',
@@ -185,12 +241,20 @@ class _DocsPageState extends State<DocsPage> with SafeSetStateMixin {
             Text(
               _searchController.text.isNotEmpty
                   ? 'No docs match your search.'
-                  : 'No docs yet.\nCreate a .abdoc file in the Files browser.',
+                  : 'No docs yet.',
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: colorScheme.onSurface.withValues(alpha: 0.5),
               ),
             ),
+            if (_searchController.text.isEmpty) ...[
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: _createNewDoc,
+                icon: const Icon(Icons.add),
+                label: const Text('Create new doc'),
+              ),
+            ],
           ],
         ),
       );

--- a/lib/pages/sheets_page.dart
+++ b/lib/pages/sheets_page.dart
@@ -6,6 +6,7 @@ import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 
 class SheetsPage extends StatefulWidget {
   const SheetsPage({super.key});
@@ -77,6 +78,58 @@ class _SheetsPageState extends State<SheetsPage> with SafeSetStateMixin {
     _load();
   }
 
+  Future<void> _createNewSheet() async {
+    final nameController = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('New Spreadsheet'),
+        content: TextField(
+          controller: nameController,
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Spreadsheet name',
+            border: OutlineInputBorder(),
+          ),
+          onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, nameController.text.trim()),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+    if (name == null || name.isEmpty || !mounted) return;
+
+    try {
+      final fileName = name.endsWith('.absheet') ? name : '$name.absheet';
+      final bytes =
+          '{"tabs":[{"name":"Sheet 1","data":{"columns":[],"rows":[]}}]}'
+              .codeUnits;
+      final file = http.MultipartFile.fromBytes(
+        'files',
+        bytes,
+        filename: fileName,
+      );
+      await CirrusService.uploadFilesFromFormData('', [file]);
+      if (!mounted) return;
+      context.push(AppRoutes.sheetFile(fileName));
+      _load();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Failed to create sheet: $e')));
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -86,6 +139,11 @@ class _SheetsPageState extends State<SheetsPage> with SafeSetStateMixin {
         label: 'Sheets',
         icon: Icons.table_chart_outlined,
         actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: 'New spreadsheet',
+            onPressed: _createNewSheet,
+          ),
           IconButton(
             icon: const Icon(Icons.refresh_rounded),
             tooltip: 'Reload',
@@ -184,12 +242,20 @@ class _SheetsPageState extends State<SheetsPage> with SafeSetStateMixin {
             Text(
               _searchController.text.isNotEmpty
                   ? 'No sheets match your search.'
-                  : 'No sheets yet.\nCreate a .absheet file in the Files browser.',
+                  : 'No sheets yet.',
               textAlign: TextAlign.center,
               style: TextStyle(
                 color: colorScheme.onSurface.withValues(alpha: 0.5),
               ),
             ),
+            if (_searchController.text.isEmpty) ...[
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                onPressed: _createNewSheet,
+                icon: const Icon(Icons.add),
+                label: const Text('Create new sheet'),
+              ),
+            ],
           ],
         ),
       );


### PR DESCRIPTION
## Summary
- The `/cirrus/by-type` Go endpoint returned a nil slice when no files matched, which gin serialized as JSON `null` instead of `[]`
- The Flutter `getFilesByType` client threw on `null` instead of treating it as an empty list
- Both docs and sheets pages already had proper empty-state UIs — they just never reached them because the service threw first
- **Added a + button in the app bar** on both docs and sheets pages to create new files directly
- **Replaced the empty-state message** ("go to the file browser") with a prominent "Create new doc/sheet" button that creates the file and opens the editor

Fixes #1179, fixes #1180. Also addresses #1189.

## Test plan
- [ ] Navigate to /docs with no .abdoc files — should show "No docs yet" with a "Create new doc" button
- [ ] Navigate to /sheets with no .absheet files — should show "No sheets yet" with a "Create new sheet" button
- [ ] Tap the + in the docs app bar — name dialog, creates file, opens editor
- [ ] Tap the + in the sheets app bar — name dialog, creates file, opens editor
- [ ] Verify docs/sheets still list files correctly when files exist
- [ ] Verify search still works and empty search result shows "No docs/sheets match" without the create button