### PR TITLE
feat: standardize create actions across content pages

### DIFF
--- a/lib/pages/docs_page.dart
+++ b/lib/pages/docs_page.dart
@@ -247,14 +247,6 @@ class _DocsPageState extends State<DocsPage> with SafeSetStateMixin {
                 color: colorScheme.onSurface.withValues(alpha: 0.5),
               ),
             ),
-            if (_searchController.text.isEmpty) ...[
-              const SizedBox(height: 16),
-              FilledButton.icon(
-                onPressed: _createNewDoc,
-                icon: const Icon(Icons.add),
-                label: const Text('Create new doc'),
-              ),
-            ],
           ],
         ),
       );

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -1152,7 +1152,7 @@ class _PhotosPageState extends State<PhotosPage>
                               height: 18,
                               child: CircularProgressIndicator(strokeWidth: 2),
                             )
-                          : const Icon(Icons.upload_rounded),
+                          : const Icon(Icons.add),
                       tooltip: 'Upload photos',
                       onPressed: _isUploading ? null : _handleUploadPhotos,
                     ),

--- a/lib/pages/photos_page.dart
+++ b/lib/pages/photos_page.dart
@@ -1,10 +1,12 @@
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/utils/auto_refresh_mixin.dart';
 import 'package:autobutler/widgets/core/empty_state_widget.dart';
+import 'package:autobutler/widgets/device_upload_picker.dart';
 import 'package:autobutler/widgets/refresh_icon_button.dart';
 import 'package:autobutler/pages/image_viewer_page.dart';
 import 'package:autobutler/services/app_settings.dart';
 import 'package:autobutler/services/cirrus_service.dart';
+import 'package:autobutler/services/storage_service.dart';
 import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
 import 'package:autobutler/models/photo_album.dart';
@@ -13,11 +15,13 @@ import 'package:autobutler/services/album_service.dart';
 import 'package:autobutler/services/favorites_service.dart';
 import 'package:autobutler/widgets/photos/album_sidebar.dart';
 import 'package:autobutler/widgets/photos/photo_selection_bar.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:autobutler/router.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 import 'package:photo_manager/photo_manager.dart';
 
 class PhotosPage extends StatefulWidget {
@@ -73,6 +77,7 @@ class _PhotosPageState extends State<PhotosPage>
 
   bool _noHostSelected = false;
   bool _categoriesExpanded = false;
+  bool _isUploading = false;
   int _previewColumns = _defaultCrossAxisCount;
   PhotoCategory _selectedCategory = PhotoCategory.cirrus;
 
@@ -989,6 +994,91 @@ class _PhotosPageState extends State<PhotosPage>
     }
   }
 
+  Future<void> _handleUploadPhotos() async {
+    if (_isUploading) return;
+
+    try {
+      final result = await FilePicker.pickFiles(
+        type: FileType.image,
+        allowMultiple: true,
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty || !mounted) return;
+
+      final multipartFiles = <http.MultipartFile>[];
+      for (final f in result.files) {
+        if (kIsWeb) {
+          if (f.bytes == null) continue;
+          multipartFiles.add(
+            http.MultipartFile.fromBytes('files', f.bytes!, filename: f.name),
+          );
+        } else if (f.path != null && f.path!.isNotEmpty) {
+          multipartFiles.add(
+            await http.MultipartFile.fromPath(
+              'files',
+              f.path!,
+              filename: f.name,
+            ),
+          );
+        } else if (f.bytes != null) {
+          multipartFiles.add(
+            http.MultipartFile.fromBytes('files', f.bytes!, filename: f.name),
+          );
+        }
+      }
+      if (multipartFiles.isEmpty || !mounted) return;
+
+      String? targetSerial;
+      try {
+        final devices = (await StorageService.listDevices())
+            .where((d) => d.isEnabled)
+            .toList();
+        if (devices.length > 1) {
+          if (!mounted) return;
+          final picked = await showDeviceUploadPicker(context, devices);
+          if (picked == null) return;
+          targetSerial = picked.serial.isNotEmpty ? picked.serial : null;
+        } else if (devices.length == 1) {
+          targetSerial = devices.first.serial.isNotEmpty
+              ? devices.first.serial
+              : null;
+        }
+      } catch (_) {}
+
+      setState(() => _isUploading = true);
+
+      try {
+        await CirrusService.uploadFilesFromFormData(
+          '',
+          multipartFiles,
+          serial: targetSerial,
+        );
+        if (!mounted) return;
+        final label = multipartFiles.length == 1
+            ? multipartFiles.first.filename ?? 'photo'
+            : '${multipartFiles.length} photos';
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Uploaded $label')));
+        await manualRefresh();
+      } catch (e) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Upload failed: $e')));
+      } finally {
+        if (mounted) setState(() => _isUploading = false);
+      }
+    } on MissingPluginException {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('File picker not available. Fully restart the app.'),
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return CallbackShortcuts(
@@ -1055,6 +1145,17 @@ class _PhotosPageState extends State<PhotosPage>
                   label: 'Photos',
                   icon: Icons.photo_library_outlined,
                   actions: [
+                    IconButton(
+                      icon: _isUploading
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.upload_rounded),
+                      tooltip: 'Upload photos',
+                      onPressed: _isUploading ? null : _handleUploadPhotos,
+                    ),
                     TextButton(
                       onPressed: _enterSelectionMode,
                       child: const Text('Select'),

--- a/lib/pages/sheets_page.dart
+++ b/lib/pages/sheets_page.dart
@@ -248,14 +248,6 @@ class _SheetsPageState extends State<SheetsPage> with SafeSetStateMixin {
                 color: colorScheme.onSurface.withValues(alpha: 0.5),
               ),
             ),
-            if (_searchController.text.isEmpty) ...[
-              const SizedBox(height: 16),
-              FilledButton.icon(
-                onPressed: _createNewSheet,
-                icon: const Icon(Icons.add),
-                label: const Text('Create new sheet'),
-              ),
-            ],
           ],
         ),
       );

--- a/lib/pages/vault_page.dart
+++ b/lib/pages/vault_page.dart
@@ -114,6 +114,11 @@ class _VaultPageState extends State<VaultPage> {
         actions: [
           if (_status?.initialized == true && !(_status?.locked ?? true)) ...[
             IconButton(
+              icon: const Icon(Icons.add),
+              tooltip: 'New entry',
+              onPressed: () => _showEntryEditor(context),
+            ),
+            IconButton(
               icon: const Icon(Icons.lock_open),
               tooltip: 'Lock vault',
               onPressed: _lockVault,
@@ -181,7 +186,9 @@ class _VaultPageState extends State<VaultPage> {
       ),
       body: _buildBody(),
       floatingActionButton:
-          (_status?.initialized == true && !(_status?.locked ?? true))
+          (_status?.initialized == true &&
+              !(_status?.locked ?? true) &&
+              MediaQuery.of(context).size.width < 860)
           ? FloatingActionButton(
               onPressed: () => _showEntryEditor(context),
               child: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- Add upload button to Photos page app bar (file picker, multi-select, device picker for multi-device setups, spinner during upload)
- Remove redundant empty-state "Create new doc/sheet" buttons from Docs and Sheets pages — the app bar `+` button is always visible and sufficient
- Add `+` (New entry) button to Vault app bar for desktop consistency
- Hide Vault FAB on desktop (width >= 860) to match File Browser's pattern: FAB for mobile, app bar actions for desktop

Closes #1189
Closes #1224
Supersedes #1247

## Test plan
- [ ] Photos page: upload button in app bar opens file picker, uploads, refreshes grid
- [ ] Photos page: upload shows spinner during upload, success/error snackbar
- [ ] Docs page: empty state shows "No docs yet" text without a create button; app bar `+` still works
- [ ] Sheets page: same as Docs
- [ ] Vault page (desktop): FAB hidden, `+` in app bar creates new entry
- [ ] Vault page (mobile/narrow): FAB still visible
- [ ] File Browser: unchanged — FAB on mobile, top bar actions on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)