### PR TITLE
feat: archive compressed size display and inline file preview (#1185)

### DIFF
--- a/internal/server/api/v1/cirrus/list_archive.go
+++ b/internal/server/api/v1/cirrus/list_archive.go
@@ -68,15 +68,16 @@ func listArchive(c *gin.Context) *serverutil.Response {
 		displayName := nameParts[len(nameParts)-1]
 
 		result[i] = FileNodeJSON{
-			Name:         displayName,
-			Size:         e.Size,
-			IsDir:        e.IsDir,
-			DeviceName:   "",
-			DevicePath:   "",
-			DirPath:      dirPath,
-			FullPath:     dirPath,
-			DeviceSerial: serial,
-			FileType:     fileType,
+			Name:           displayName,
+			Size:           e.Size,
+			CompressedSize: e.CompressedSize,
+			IsDir:          e.IsDir,
+			DeviceName:     "",
+			DevicePath:     "",
+			DirPath:        dirPath,
+			FullPath:       dirPath,
+			DeviceSerial:   serial,
+			FileType:       fileType,
 		}
 	}
 

--- a/internal/server/api/v1/cirrus/list_files.go
+++ b/internal/server/api/v1/cirrus/list_files.go
@@ -17,15 +17,16 @@ const DefaultDeviceSerial = ""
 
 // FileNodeJSON is a JSON-serializable representation of a file node
 type FileNodeJSON struct {
-	Name         string `json:"name"`
-	Size         int64  `json:"size"`
-	IsDir        bool   `json:"isDir"`
-	DeviceName   string `json:"deviceName"`
-	DevicePath   string `json:"devicePath"`
-	DirPath      string `json:"dirPath"` // Directory path containing the file, for easier client-side handling
-	FullPath     string `json:"fullPath"`
-	DeviceSerial string `json:"deviceSerial"`
-	FileType     string `json:"fileType"`
+	Name           string `json:"name"`
+	Size           int64  `json:"size"`
+	CompressedSize int64  `json:"compressedSize,omitempty"`
+	IsDir          bool   `json:"isDir"`
+	DeviceName     string `json:"deviceName"`
+	DevicePath     string `json:"devicePath"`
+	DirPath        string `json:"dirPath"` // Directory path containing the file, for easier client-side handling
+	FullPath       string `json:"fullPath"`
+	DeviceSerial   string `json:"deviceSerial"`
+	FileType       string `json:"fileType"`
 }
 
 func listFilesImpl(rootDir string, devices []storageutil.ManagedDevice) ([]FileNodeJSON, error) {

--- a/lib/models/cirrus_file_node.dart
+++ b/lib/models/cirrus_file_node.dart
@@ -8,10 +8,12 @@ class CirrusFileNode {
     required this.deviceSerial,
     required this.dirPath,
     this.fileType = '',
+    this.compressedSize = 0,
   });
 
   final String name;
   final int size;
+  final int compressedSize;
   final bool isDir;
   final String deviceName;
   final String devicePath;
@@ -56,6 +58,9 @@ class CirrusFileNode {
     return CirrusFileNode(
       name: parseString(json['name']),
       size: parseSize(json['size']),
+      compressedSize: parseSize(
+        json['compressedSize'] ?? json['compressed_size'],
+      ),
       isDir: parseBool(json['isDir'] ?? json['is_dir']),
       deviceName: parseString(json['deviceName'] ?? json['device_name']),
       devicePath: parseString(json['devicePath'] ?? json['device_path']),

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -5,6 +5,7 @@ import 'package:autobutler/controllers/file_browser_cache.dart';
 import 'package:autobutler/controllers/file_browser_controller.dart';
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/pages/document_editor_page.dart';
+import 'package:autobutler/pages/image_viewer_page.dart';
 import 'package:autobutler/pages/spreadsheet_editor_page.dart';
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/app_settings.dart';
@@ -904,6 +905,12 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       return;
     }
 
+    // When inside an archive, preview files inline where possible.
+    if (_archiveContext != null) {
+      await _openArchiveFile(node);
+      return;
+    }
+
     // Navigate into archives as virtual directories.
     if (node.fileType == 'archive') {
       _openArchive(node);
@@ -943,6 +950,60 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     // file type via FileViewerPage and opens the correct viewer. This updates
     // the URL bar so the link is always shareable.
     _openFileViaRoute(node.apiPath);
+  }
+
+  static const _kImageExtensions = {
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.bmp',
+    '.webp',
+    '.tiff',
+    '.tif',
+  };
+
+  Future<void> _openArchiveFile(CirrusFileNode node) async {
+    final archive = _archiveContext!;
+    final entryPath = archive.subPath.isEmpty
+        ? node.name
+        : '${archive.subPath}/${node.name}';
+    final ext = node.name.contains('.')
+        ? '.${node.name.split('.').last.toLowerCase()}'
+        : '';
+
+    try {
+      final bytes = await CirrusService.downloadArchiveFileBytes(
+        archive.archivePath,
+        entryPath,
+      );
+      if (bytes == null || !mounted) return;
+
+      if (_kImageExtensions.contains(ext)) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => ImageViewerPage(bytes: bytes, name: node.name),
+          ),
+        );
+        return;
+      }
+
+      if (_kTextExtensions.contains(ext)) {
+        final text = utf8.decode(bytes, allowMalformed: true);
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => _ArchiveTextPreview(name: node.name, text: text),
+          ),
+        );
+        return;
+      }
+
+      // Fallback: download the file.
+      await CirrusService.saveBytesToFile(bytes, node.name);
+      if (mounted) _showMessage('Downloaded ${node.name}');
+    } catch (e) {
+      if (mounted) _showMessage('Failed to open file: $e');
+    }
   }
 
   void _openDirectory(CirrusFileNode node) {
@@ -1908,4 +1969,24 @@ class _ArchiveContext {
 
   /// Device serial of the device that holds the archive.
   final String archiveSerial;
+}
+
+class _ArchiveTextPreview extends StatelessWidget {
+  const _ArchiveTextPreview({required this.name, required this.text});
+  final String name;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(name)),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: SelectableText(
+          text,
+          style: const TextStyle(fontFamily: 'monospace', fontSize: 13),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -269,7 +269,11 @@ class _FileBrowserViewState extends State<FileBrowserView> {
               Expanded(
                 flex: 2,
                 child: Text(
-                  _formatSize(item.size, item.isDir),
+                  _formatSize(
+                    item.size,
+                    item.isDir,
+                    compressedSize: item.compressedSize,
+                  ),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: TextStyle(color: colors.onSurfaceVariant),
@@ -524,7 +528,11 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                                     if (widget.showFileSizeAndMenu)
                                       Flexible(
                                         child: Text(
-                                          _formatSize(item.size, item.isDir),
+                                          _formatSize(
+                                            item.size,
+                                            item.isDir,
+                                            compressedSize: item.compressedSize,
+                                          ),
                                           maxLines: 1,
                                           overflow: TextOverflow.ellipsis,
                                         ),
@@ -702,8 +710,16 @@ class _FileBrowserViewState extends State<FileBrowserView> {
     return node.name.substring(dot + 1).toLowerCase();
   }
 
-  static String _formatSize(int bytes, bool isDir) {
+  static String _formatSize(int bytes, bool isDir, {int compressedSize = 0}) {
     if (isDir) return '--';
+    final sizeStr = _formatBytes(bytes);
+    if (compressedSize > 0 && compressedSize != bytes) {
+      return '${_formatBytes(compressedSize)} → $sizeStr';
+    }
+    return sizeStr;
+  }
+
+  static String _formatBytes(int bytes) {
     if (bytes < 1024) return '$bytes B';
     if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
     if (bytes < 1024 * 1024 * 1024) {

--- a/pkg/util/storageutil/archive_list.go
+++ b/pkg/util/storageutil/archive_list.go
@@ -9,15 +9,17 @@ import (
 	"strings"
 	"time"
 
+	kzip "github.com/klauspost/compress/zip"
 	"github.com/mholt/archiver/v4"
 )
 
 // ArchiveEntry represents a single entry visible at a given level inside an archive.
 type ArchiveEntry struct {
-	Name    string
-	Size    int64
-	IsDir   bool
-	ModTime time.Time
+	Name           string
+	Size           int64
+	CompressedSize int64
+	IsDir          bool
+	ModTime        time.Time
 }
 
 // ListArchiveParams contains parameters for listing archive contents.
@@ -145,6 +147,9 @@ func listArchiveEntries(fullPath, subPath string) ([]ArchiveEntry, error) {
 			}
 			if slash < 0 {
 				entry.Size = af.Size()
+				if zh, ok := af.Header.(kzip.FileHeader); ok {
+					entry.CompressedSize = int64(zh.CompressedSize64)
+				}
 			}
 			seen[childName] = entry
 		}

--- a/pkg/util/storageutil/archive_list_test.go
+++ b/pkg/util/storageutil/archive_list_test.go
@@ -208,6 +208,48 @@ func TestListArchiveEntriesImpl_InvalidSubPath(t *testing.T) {
 	}
 }
 
+func TestListArchiveEntriesImpl_ZipCompressedSize(t *testing.T) {
+	device := makeListDevice(t)
+
+	// Build a zip with deflate compression so compressed != uncompressed.
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	content := bytes.Repeat([]byte("abcdefghij"), 100) // 1000 bytes, highly compressible
+	fw, err := w.CreateHeader(&zip.FileHeader{
+		Name:   "compressible.txt",
+		Method: zip.Deflate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write(content); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	writeArchive(t, device.CirrusDir, "compressed.zip", buf.Bytes())
+
+	entries, err := ListArchiveEntriesImpl(ListArchiveParams{FilePath: "compressed.zip"}, device, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	e := entries[0]
+	if e.Size != 1000 {
+		t.Errorf("expected uncompressed size 1000, got %d", e.Size)
+	}
+	if e.CompressedSize <= 0 {
+		t.Errorf("expected positive compressed size, got %d", e.CompressedSize)
+	}
+	if e.CompressedSize >= e.Size {
+		t.Errorf("expected compressed size (%d) < uncompressed size (%d)", e.CompressedSize, e.Size)
+	}
+}
+
 func TestNormalizeSubPath(t *testing.T) {
 	cases := []struct {
 		input string


### PR DESCRIPTION
## Summary
- Add compressed size to archive entry listings for zip format, using klauspost/compress zip headers
- Display compressed → uncompressed sizes in the file browser when compressed size is available
- Enable inline preview of images and text files inside archives without full extraction

## Changes
- **Backend**: `ArchiveEntry.CompressedSize` field populated from zip `FileHeader.CompressedSize64`; flowed through `FileNodeJSON` API response
- **Frontend**: `_formatSize` shows "compressed → uncompressed" when both values are present; `_openArchiveFile` routes tapped archive entries to `ImageViewerPage` or `_ArchiveTextPreview` based on extension
- **Test**: `TestListArchiveEntriesImpl_ZipCompressedSize` verifies compressed size is populated and smaller than uncompressed size for deflate-compressed zip entries

## Test plan
- [ ] Verify compressed size appears in file browser for zip archives with deflate compression
- [ ] Verify plain (stored) zip entries and tar.gz entries show only uncompressed size
- [ ] Verify tapping an image inside a zip/tar.gz opens the image viewer
- [ ] Verify tapping a text file inside an archive shows inline text preview
- [ ] Verify tapping an unsupported file type inside an archive falls back to download
- [ ] Run `go test ./pkg/util/storageutil/...` — all tests pass

Closes #1185