### PR TITLE
fix: reject thumbnail generation for unsupported file types

### DIFF
--- a/internal/server/api/v1/thumbnails/get_thumbnail.go
+++ b/internal/server/api/v1/thumbnails/get_thumbnail.go
@@ -144,6 +144,9 @@ var getThumbnailRoute = serverutil.ApiRoute(
 
 		ext := strings.ToLower(filepath.Ext(filePath))
 		fileType := storageutil.DetermineFileTypeFromPath("file" + ext)
+		if fileType != storageutil.FileTypeImage && fileType != storageutil.FileTypeVideo {
+			return serverutil.NotFound(fmt.Errorf("no thumbnail for file type %q: %s", fileType, filePath))
+		}
 		isVideo := fileType == storageutil.FileTypeVideo
 
 		// --- Server-side rotation ---

--- a/pkg/util/photoutil/photoutil_test.go
+++ b/pkg/util/photoutil/photoutil_test.go
@@ -255,6 +255,24 @@ func TestGenerateThumbnail_Error(t *testing.T) {
 	}
 }
 
+func TestGenerateThumbnail_UnsupportedFileType(t *testing.T) {
+	tmpDir := t.TempDir()
+	unsupported := filepath.Join(tmpDir, "document.psd")
+	os.WriteFile(unsupported, []byte("fake psd content"), 0644)
+
+	result, err := GenerateThumbnail(GenerateThumbnailParams{
+		FilePath: unsupported,
+		Width:    50,
+		Height:   50,
+	})
+	if err == nil {
+		t.Fatal("Expected error for unsupported file type")
+	}
+	if result != nil {
+		t.Error("Expected nil result for unsupported file type")
+	}
+}
+
 func TestCorrectImageOrientation_NoEXIF(t *testing.T) {
 	img := image.NewRGBA(image.Rect(0, 0, 10, 10))
 

--- a/pkg/util/photoutil/service.go
+++ b/pkg/util/photoutil/service.go
@@ -28,6 +28,10 @@ func GenerateThumbnail(params GenerateThumbnailParams) (*GenerateThumbnailResult
 	ext := strings.ToLower(filepath.Ext(params.FilePath))
 	fileType := storageutil.DetermineFileTypeFromPath("file" + ext)
 
+	if fileType != storageutil.FileTypeImage && fileType != storageutil.FileTypeVideo {
+		return nil, fmt.Errorf("unsupported file type for thumbnail: %s", ext)
+	}
+
 	if fileType == storageutil.FileTypeVideo {
 		if !IsFFmpegAvailable() {
 			return nil, fmt.Errorf("ffmpeg is required for video thumbnails but was not found on PATH")


### PR DESCRIPTION
## Summary
- Gate the thumbnail endpoint (`/thumbnails/*`) to only generate thumbnails for image and video files, returning 404 for all other file types
- Add a defense-in-depth guard in `GenerateThumbnail()` that rejects unsupported file types before reaching `image.Decode()`
- The client already falls back to a generic file icon when the thumbnail endpoint returns an error, so no frontend changes are needed

## Root Cause
The thumbnail endpoint called `GenerateThumbnail` → `ImageToThumbnail` → `image.Decode()` on **every file type** regardless of whether it was actually an image. Go's `image.Decode` can accidentally partially parse some non-image binary formats, producing a garbage JPEG that gets cached and served as a "preview." This made it appear as if unsupported files were silently converted to JPEG.

## Test plan
- [x] Added `TestGenerateThumbnail_UnsupportedFileType` — verifies `.psd` files are rejected
- [x] Existing `TestGenerateThumbnail` still passes (valid images still work)
- [x] Existing `TestGenerateThumbnail_Error` still passes
- [ ] Manual: upload a `.psd` or other unsupported file, verify it shows a generic file icon instead of a garbage JPEG preview

Closes #1178