### PR TITLE
feat: generic file viewer for unsupported file types

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -5,6 +5,7 @@ import 'package:autobutler/controllers/file_browser_cache.dart';
 import 'package:autobutler/controllers/file_browser_controller.dart';
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/pages/document_editor_page.dart';
+import 'package:autobutler/pages/generic_file_viewer_page.dart';
 import 'package:autobutler/pages/spreadsheet_editor_page.dart';
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/app_settings.dart';
@@ -939,6 +940,17 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       return;
     }
 
+    // Generic / unsupported file types — show a detail view with download and
+    // "Open with" actions instead of silently failing.
+    if (node.fileType == 'generic' || node.fileType.isEmpty) {
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (_) => GenericFileViewerPage(node: node),
+        ),
+      );
+      return;
+    }
+
     // All other file types — navigate to /cirrus/<path> which resolves the
     // file type via FileViewerPage and opens the correct viewer. This updates
     // the URL bar so the link is always shareable.
@@ -1419,6 +1431,25 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           ),
         );
         if (!mounted) return;
+        return;
+      case 'generic':
+        final name = filePath.split('/').last;
+        final node = CirrusFileNode(
+          name: name,
+          size: 0,
+          isDir: false,
+          deviceName: '',
+          devicePath: '',
+          deviceSerial: '',
+          dirPath: filePath,
+          fileType: fileType,
+        );
+        FileBrowserCache.instance.markFileOpen(filePath);
+        Navigator.of(context).push(
+          MaterialPageRoute<void>(
+            builder: (_) => GenericFileViewerPage(node: node),
+          ),
+        );
         return;
       default:
         setState(() {

--- a/lib/pages/generic_file_viewer_open_native.dart
+++ b/lib/pages/generic_file_viewer_open_native.dart
@@ -1,0 +1,16 @@
+import 'dart:io' show File;
+import 'dart:typed_data';
+
+import 'package:open_filex/open_filex.dart';
+import 'package:path_provider/path_provider.dart';
+
+Future<String> openFileWithSystem(Uint8List bytes, String fileName) async {
+  final tempDir = await getTemporaryDirectory();
+  final tempFile = File('${tempDir.path}/$fileName');
+  await tempFile.writeAsBytes(bytes);
+  final result = await OpenFilex.open(tempFile.path);
+  if (result.type != ResultType.done) {
+    return result.message;
+  }
+  return '';
+}

--- a/lib/pages/generic_file_viewer_open_stub.dart
+++ b/lib/pages/generic_file_viewer_open_stub.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+Future<String> openFileWithSystem(Uint8List bytes, String fileName) async {
+  throw UnsupportedError('openFileWithSystem is not available on web');
+}

--- a/lib/pages/generic_file_viewer_page.dart
+++ b/lib/pages/generic_file_viewer_page.dart
@@ -1,0 +1,175 @@
+import 'package:autobutler/models/cirrus_file_node.dart';
+import 'package:autobutler/services/cirrus_service.dart';
+import 'package:autobutler/widgets/core/autobutler_file_icon.dart';
+import 'package:autobutler/widgets/layout/theme_toggle_button.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:autobutler/pages/generic_file_viewer_open_stub.dart'
+    if (dart.library.io) 'package:autobutler/pages/generic_file_viewer_open_native.dart'
+    as native_open;
+
+class GenericFileViewerPage extends StatefulWidget {
+  final CirrusFileNode node;
+
+  const GenericFileViewerPage({super.key, required this.node});
+
+  @override
+  State<GenericFileViewerPage> createState() => _GenericFileViewerPageState();
+}
+
+class _GenericFileViewerPageState extends State<GenericFileViewerPage> {
+  bool _downloading = false;
+  bool _opening = false;
+
+  String get _extension {
+    final name = widget.node.name;
+    final idx = name.lastIndexOf('.');
+    if (idx < 0 || idx == name.length - 1) return '';
+    return name.substring(idx).toLowerCase();
+  }
+
+  String get _typeLabel {
+    if (_extension.isEmpty) return 'Unknown file';
+    return '${_extension.substring(1).toUpperCase()} file';
+  }
+
+  Future<void> _handleDownload() async {
+    if (_downloading) return;
+    setState(() => _downloading = true);
+    try {
+      await CirrusService.saveFile(
+        widget.node.apiPath,
+        serial: widget.node.deviceSerial.isEmpty
+            ? null
+            : widget.node.deviceSerial,
+        fileName: widget.node.name,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Downloaded ${widget.node.name}')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Download failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _downloading = false);
+    }
+  }
+
+  Future<void> _handleOpenWith() async {
+    if (_opening || kIsWeb) return;
+    setState(() => _opening = true);
+    try {
+      final bytes = await CirrusService.downloadFileBytes(
+        widget.node.apiPath,
+        serial: widget.node.deviceSerial.isEmpty
+            ? null
+            : widget.node.deviceSerial,
+      );
+      if (bytes == null) throw Exception('Download returned no data');
+      final message = await native_open.openFileWithSystem(
+        bytes,
+        widget.node.name,
+      );
+      if (message.isNotEmpty && mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(message)));
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Could not open file: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _opening = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.node.name),
+        actions: const [ThemeToggleButton()],
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AutobutlerFileIcon(
+                node: widget.node,
+                size: 80,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                widget.node.name,
+                style: theme.textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                widget.node.size > 0
+                    ? '$_typeLabel  ·  ${_formatSize(widget.node.size)}'
+                    : _typeLabel,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 32),
+              Wrap(
+                alignment: WrapAlignment.center,
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  FilledButton.icon(
+                    onPressed: _downloading ? null : _handleDownload,
+                    icon: _downloading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.download),
+                    label: const Text('Download'),
+                  ),
+                  if (!kIsWeb)
+                    OutlinedButton.icon(
+                      onPressed: _opening ? null : _handleOpenWith,
+                      icon: _opening
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.open_in_new),
+                      label: const Text('Open with…'),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _formatSize(int bytes) {
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    if (bytes < 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+    }
+    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+  }
+}


### PR DESCRIPTION
## Summary
- New `GenericFileViewerPage` that shows file icon, name, type label, and size for any file type without a dedicated viewer
- Download button (all platforms) and "Open with..." button (native only, via `open_filex`) let users still work with unsupported files
- Replaces the silent "No supported editor" dead-end when tapping generic files in the file browser
- Handles both file-listing taps (`_handleOpenNode`) and deep-link navigation (`_openPendingFileInner`)
- Uses conditional imports (`dart.library.io`) so the web build stays clean — no `dart:io` on web

## Root Cause
Previously, tapping an unsupported file type (e.g. `.psd`, `.ai`, `.sketch`) either showed a vague "No supported editor" error or silently navigated back to the file browser. Users had no way to download or open these files.

## Test plan
- [ ] Upload an unsupported file type (e.g. `.psd`, `.ai`, `.sketch`) via drag-and-drop or file picker
- [ ] Tap the file — verify it opens the generic detail view with icon, name, type, and size
- [ ] Click Download — verify the file downloads correctly
- [ ] On native (macOS): click "Open with..." — verify it hands off to the system default app
- [ ] On web: verify the "Open with..." button is not shown
- [ ] Deep-link to a generic file via URL — verify the detail view opens instead of "No supported editor"
- [ ] Verify existing file types (images, video, abdoc, absheet, text) still open in their respective viewers

Closes #1188