### PR TITLE
fix(#1311): highlight color no longer stacks when changed

### DIFF
--- a/lib/pages/document_editor_page.dart
+++ b/lib/pages/document_editor_page.dart
@@ -750,6 +750,9 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
                   QuillToolbarSelectHeaderStyleDropdownButtonOptions(
                     textStyle: TextStyle(color: cs.onSurface, fontSize: 13),
                   ),
+              backgroundColor: QuillToolbarColorButtonOptions(
+                customOnPressedCallback: _pickBackgroundColor,
+              ),
             ),
             showFontFamily: false,
             showFontSize: false,
@@ -890,6 +893,34 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
     );
   }
 
+  Future<void> _pickBackgroundColor(
+    QuillController controller,
+    bool isBackground,
+  ) async {
+    if (!mounted) return;
+    // Save selection before the dialog steals focus (web loses it otherwise).
+    final saved = controller.selection;
+
+    final picked = await showDialog<Color?>(
+      context: context,
+      builder: (_) => const _HighlightPickerDialog(),
+    );
+
+    if (!mounted) return;
+    if (picked == null) return; // cancelled
+
+    // Restore selection in case web dropped it while the dialog was open.
+    if (saved.isValid) {
+      controller.updateSelection(saved, ChangeSource.local);
+    }
+
+    // Always clear first so we never visually stack two background colors.
+    controller.formatSelection(const BackgroundAttribute(null));
+    if (picked != Colors.transparent) {
+      controller.formatSelection(BackgroundAttribute(_colorToHex(picked)));
+    }
+  }
+
   Future<bool> _confirmDiscard(BuildContext context) async {
     final result = await showDialog<bool>(
       context: context,
@@ -909,5 +940,66 @@ class _DocumentEditorPageState extends State<DocumentEditorPage> {
       ),
     );
     return result ?? false;
+  }
+}
+
+// Produces "#AARRGGBB" matching flutter_quill's BackgroundAttribute storage format.
+String _colorToHex(Color color) {
+  int ch(double v) => (v * 255).round() & 0xFF;
+  return '#'
+          '${ch(color.a).toRadixString(16).padLeft(2, '0')}'
+          '${ch(color.r).toRadixString(16).padLeft(2, '0')}'
+          '${ch(color.g).toRadixString(16).padLeft(2, '0')}'
+          '${ch(color.b).toRadixString(16).padLeft(2, '0')}'
+      .toUpperCase();
+}
+
+class _HighlightPickerDialog extends StatelessWidget {
+  const _HighlightPickerDialog();
+
+  static const _colors = <Color>[
+    Color(0xFFFFEB3B), // Yellow
+    Color(0xFF8BC34A), // Green
+    Color(0xFF4FC3F7), // Blue
+    Color(0xFFF48FB1), // Pink
+    Color(0xFFCE93D8), // Lavender
+    Color(0xFFFFCC80), // Orange
+    Color(0xFFEF9A9A), // Red
+    Color(0xFF80DEEA), // Cyan
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Highlight color'),
+      content: Wrap(
+        spacing: 10,
+        runSpacing: 10,
+        children: _colors.map((c) {
+          return GestureDetector(
+            onTap: () => Navigator.of(context).pop(c),
+            child: Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: c,
+                shape: BoxShape.circle,
+                border: Border.all(color: Colors.black26, width: 1.5),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(Colors.transparent),
+          child: const Text('Clear'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Replaces the default flutter_quill background color button with a custom `customOnPressedCallback` that correctly replaces instead of stacks highlight colors
- Saves and restores the text selection around the dialog open (web drops the selection when a dialog steals focus, causing `formatSelection` to operate on zero characters and leave the old color untouched)
- Always calls `formatSelection(BackgroundAttribute(null))` before applying the new color, so there is no path where two background colors coexist on the same text
- Swaps the full color wheel dialog for a simple 8-swatch grid (yellow, green, blue, pink, lavender, orange, red, cyan) with a Clear button — avoids the live-apply-on-drag `ColorPicker` tab that was also applying intermediate dark colors during dragging

## Root cause

flutter_quill 11.5.0 had two compounding bugs:
1. `colorToHex` produces 8-char AARRGGBB hex, but `hexToColor`'s regex only matches 3 or 6 chars — so the picker always opened with `Colors.black` as the pre-selected color regardless of the current highlight
2. On Flutter web, opening the `AlertDialog` moves focus away from the editor, collapsing or clearing `controller.selection` — so `formatSelection` silently did nothing and the old color remained

## Test plan

- [ ] Select text, apply yellow highlight → text shows yellow
- [ ] With yellow text selected, open highlight picker and choose green → text shows green only (no dark blending)
- [ ] Click "Clear" → highlight is removed
- [ ] Click "Cancel" → no change to existing highlight
- [ ] Repeat changing colors several times to confirm no accumulation