### PR TITLE
fix(#1312): open images and videos from Cirrus file browser

### DIFF
--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -1451,7 +1451,11 @@ class _FileBrowserPageState extends State<FileBrowserPage>
             serial: serial,
           ),
         );
+        // Navigate back to the folder — ImageViewerPage closes via Navigator.pop
+        // and does not reset the URL, so go_router would re-evaluate the file
+        // path as a directory and show an empty listing otherwise.
         if (!mounted) return;
+        context.go(AppRoutes.cirrusPath(parentPath(filePath)));
         return;
 
       case 'video':
@@ -1467,6 +1471,7 @@ class _FileBrowserPageState extends State<FileBrowserPage>
           builder: (_, _) => VideoViewerPage(url: url, name: fileName),
         );
         if (!mounted) return;
+        context.go(AppRoutes.cirrusPath(parentPath(filePath)));
         return;
 
       default:

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -5,7 +5,9 @@ import 'package:autobutler/controllers/file_browser_cache.dart';
 import 'package:autobutler/controllers/file_browser_controller.dart';
 import 'package:autobutler/models/cirrus_file_node.dart';
 import 'package:autobutler/pages/document_editor_page.dart';
+import 'package:autobutler/pages/image_viewer_page.dart';
 import 'package:autobutler/pages/spreadsheet_editor_page.dart';
+import 'package:autobutler/pages/video_viewer_page.dart';
 import 'package:autobutler/router.dart';
 import 'package:autobutler/services/app_settings.dart';
 import 'package:autobutler/services/cirrus_service.dart';
@@ -1356,10 +1358,12 @@ class _FileBrowserPageState extends State<FileBrowserPage>
     // Stat the backend to resolve the real type.
     late final bool isDir;
     late final String fileType;
+    late final String fileName;
     try {
       final stat = await CirrusService.statFile(filePath);
       isDir = stat.isDir;
       fileType = stat.fileType;
+      fileName = stat.name.isEmpty ? filePath.split('/').last : stat.name;
     } on CirrusRequestException catch (error) {
       if (!mounted) return;
       if (isLikelyFilePath(filePath)) {
@@ -1420,6 +1424,51 @@ class _FileBrowserPageState extends State<FileBrowserPage>
         );
         if (!mounted) return;
         return;
+
+      case 'image':
+        final serials = _serialsForActiveDevices();
+        final serial = serials.isNotEmpty ? serials.first : null;
+        final bytes = await CirrusService.downloadFileBytes(
+          filePath,
+          serial: serial,
+        );
+        if (!mounted) return;
+        if (bytes == null) {
+          setState(() {
+            _routeFailure = _CirrusRouteFailure(
+              requestedPath: filePath,
+              isFileRoute: true,
+            );
+          });
+          return;
+        }
+        await _openEditorWithUrl(
+          filePath: filePath,
+          builder: (_, _) => ImageViewerPage(
+            bytes: bytes,
+            name: fileName,
+            relPath: filePath,
+            serial: serial,
+          ),
+        );
+        if (!mounted) return;
+        return;
+
+      case 'video':
+      case 'audio':
+        final videoSerials = _serialsForActiveDevices();
+        final videoSerial = videoSerials.isNotEmpty ? videoSerials.first : null;
+        final url = CirrusService.constructMediaUrl(
+          filePath,
+          serial: videoSerial,
+        );
+        await _openEditorWithUrl(
+          filePath: filePath,
+          builder: (_, _) => VideoViewerPage(url: url, name: fileName),
+        );
+        if (!mounted) return;
+        return;
+
       default:
         setState(() {
           _routeFailure = _CirrusRouteFailure(

--- a/pkg/util/storageutil/storageutil.go
+++ b/pkg/util/storageutil/storageutil.go
@@ -119,7 +119,10 @@ func DetermineFileTypeFromPath(filePath string) FileType {
 		return FileTypePDF
 	case ".pptx", ".ppt":
 		return FileTypeSlideshow
-	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".heic", ".heif", ".webp", ".bmp", ".tiff", ".tif", ".avif":
+	case ".png", ".jpg", ".jpeg", ".gif", ".svg", ".heic", ".heif", ".webp", ".bmp", ".tiff", ".tif", ".avif",
+		// Raw camera formats
+		".cr2", ".cr3", ".nef", ".nrw", ".arw", ".srf", ".sr2",
+		".orf", ".rw2", ".pef", ".dng", ".raf", ".rwl", ".x3f":
 		return FileTypeImage
 	case ".mp4", ".m4v", ".webm", ".ogg", ".ogv", ".avi", ".mov", ".mkv", ".wmv", ".flv", ".3gp", ".3g2", ".mpeg", ".mpg", ".ts":
 		return FileTypeVideo


### PR DESCRIPTION
## Summary

- **Server**: Added raw camera formats to `DetermineFileTypeFromPath` in `storageutil.go` — `.cr2`, `.cr3`, `.nef`, `.nrw`, `.arw`, `.srf`, `.sr2`, `.orf`, `.rw2`, `.pef`, `.dng`, `.raf`, `.rwl`, `.x3f` now return `FileTypeImage` instead of falling through to `FileTypeGeneric`
- **Client**: Added `'image'`, `'video'`, and `'audio'` cases to `_openPendingFileInner` in `file_browser_page.dart`, mirroring the logic in `FileViewerPage` — images download bytes and push `ImageViewerPage`, video/audio constructs a media URL and pushes `VideoViewerPage`

## Root cause

`_openPendingFileInner` only had cases for `'abdoc'` and `'absheet'`; every other file type hit the `default:` branch and set `_routeFailure` with `isUnsupported: true`. The router previously handled image/video via `FileViewerPage` but that page is no longer wired to the router (only Cirrus paths are), so the handling was never ported into the file browser.

The CR2 bug was compounded because even if the client routing had been correct, `.cr2` files were classified as `generic` on the server side, so they would still have been treated as unsupported.

## Test plan

- [ ] Click a `.jpg` or `.png` in Cirrus — opens `ImageViewerPage`
- [ ] Click a `.cr2` (raw camera file) — classified as image, opens viewer
- [ ] Click an `.mp4` — opens `VideoViewerPage`
- [ ] Click a `.mov` — opens `VideoViewerPage` (with the "unsupported format" download fallback for web)
- [ ] Cancel / close the viewer — returns to the file listing
- [ ] Image viewer shows the file name, not a raw path