### PR TITLE
feat: expiring public share links (#1338)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1954,6 +1954,112 @@ const docTemplate = `{
                 }
             }
         },
+        "/public/shares/{token}": {
+            "get": {
+                "description": "Streams the shared file (folders are zipped). Always served as an attachment with sniffing disabled so shared content can never execute in the app's origin.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Download a shared file or folder (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Share password",
+                        "name": "password",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "401": {
+                        "description": "Password required",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Wrong password",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone (expired)",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/public/shares/{token}/info": {
+            "get": {
+                "description": "Returns metadata about a share link. For password-protected shares the target name and size are withheld until the correct password is supplied via X-Share-Password or ?password=.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Get share link metadata (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Share password",
+                        "name": "password",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.shareInfoJSON"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone (expired)",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/sbom": {
             "get": {
                 "description": "Returns the Go version and all embedded dependency information from the compiled binary",
@@ -2037,6 +2143,117 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/shares": {
+            "get": {
+                "description": "Returns all share links, newest first, including expired ones.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "List share links",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v1_shares.shareJSON"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a tokenized public link for a file or folder, optionally password-protected and/or expiring.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Create a public share link",
+                "parameters": [
+                    {
+                        "description": "Share definition",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.createShareRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.shareJSON"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/shares/{id}": {
+            "delete": {
+                "description": "Deletes a share link by ID. The public URL stops working immediately.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Revoke a share link",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/serverutil.Response"
                         }
@@ -3237,6 +3454,81 @@ const docTemplate = `{
             "properties": {
                 "autoUpdate": {
                     "type": "boolean"
+                }
+            }
+        },
+        "v1_shares.createShareRequest": {
+            "type": "object",
+            "properties": {
+                "deviceSerial": {
+                    "type": "string"
+                },
+                "expiresInHours": {
+                    "description": "ExpiresInHours, when \u003e 0, sets the link expiry relative to now.\n0 means the link never expires.",
+                    "type": "integer"
+                },
+                "filePath": {
+                    "type": "string"
+                },
+                "password": {
+                    "description": "Password, when non-empty, protects the link.",
+                    "type": "string"
+                }
+            }
+        },
+        "v1_shares.shareInfoJSON": {
+            "type": "object",
+            "properties": {
+                "expiresAt": {
+                    "type": "string"
+                },
+                "isFolder": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Name and IsFolder are omitted until the password (if any) is supplied,\nso a protected link leaks nothing about its target.",
+                    "type": "string"
+                },
+                "passwordProtected": {
+                    "type": "boolean"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v1_shares.shareJSON": {
+            "type": "object",
+            "properties": {
+                "accessCount": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "deviceSerial": {
+                    "type": "string"
+                },
+                "expired": {
+                    "type": "boolean"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "filePath": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastAccessAt": {
+                    "type": "string"
+                },
+                "passwordProtected": {
+                    "type": "boolean"
+                },
+                "urlPath": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1943,6 +1943,112 @@
                 }
             }
         },
+        "/public/shares/{token}": {
+            "get": {
+                "description": "Streams the shared file (folders are zipped). Always served as an attachment with sniffing disabled so shared content can never execute in the app's origin.",
+                "produces": [
+                    "application/octet-stream"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Download a shared file or folder (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Share password",
+                        "name": "password",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "401": {
+                        "description": "Password required",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Wrong password",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone (expired)",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/public/shares/{token}/info": {
+            "get": {
+                "description": "Returns metadata about a share link. For password-protected shares the target name and size are withheld until the correct password is supplied via X-Share-Password or ?password=.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Get share link metadata (public)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Share token",
+                        "name": "token",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Share password",
+                        "name": "password",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.shareInfoJSON"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "410": {
+                        "description": "Gone (expired)",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/sbom": {
             "get": {
                 "description": "Returns the Go version and all embedded dependency information from the compiled binary",
@@ -2026,6 +2132,117 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/shares": {
+            "get": {
+                "description": "Returns all share links, newest first, including expired ones.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "List share links",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/v1_shares.shareJSON"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "Creates a tokenized public link for a file or folder, optionally password-protected and/or expiring.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Create a public share link",
+                "parameters": [
+                    {
+                        "description": "Share definition",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.createShareRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1_shares.shareJSON"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/shares/{id}": {
+            "delete": {
+                "description": "Deletes a share link by ID. The public URL stops working immediately.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "shares"
+                ],
+                "summary": "Revoke a share link",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/serverutil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/serverutil.Response"
                         }
@@ -3226,6 +3443,81 @@
             "properties": {
                 "autoUpdate": {
                     "type": "boolean"
+                }
+            }
+        },
+        "v1_shares.createShareRequest": {
+            "type": "object",
+            "properties": {
+                "deviceSerial": {
+                    "type": "string"
+                },
+                "expiresInHours": {
+                    "description": "ExpiresInHours, when \u003e 0, sets the link expiry relative to now.\n0 means the link never expires.",
+                    "type": "integer"
+                },
+                "filePath": {
+                    "type": "string"
+                },
+                "password": {
+                    "description": "Password, when non-empty, protects the link.",
+                    "type": "string"
+                }
+            }
+        },
+        "v1_shares.shareInfoJSON": {
+            "type": "object",
+            "properties": {
+                "expiresAt": {
+                    "type": "string"
+                },
+                "isFolder": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "description": "Name and IsFolder are omitted until the password (if any) is supplied,\nso a protected link leaks nothing about its target.",
+                    "type": "string"
+                },
+                "passwordProtected": {
+                    "type": "boolean"
+                },
+                "sizeBytes": {
+                    "type": "integer"
+                }
+            }
+        },
+        "v1_shares.shareJSON": {
+            "type": "object",
+            "properties": {
+                "accessCount": {
+                    "type": "integer"
+                },
+                "createdAt": {
+                    "type": "string"
+                },
+                "deviceSerial": {
+                    "type": "string"
+                },
+                "expired": {
+                    "type": "boolean"
+                },
+                "expiresAt": {
+                    "type": "string"
+                },
+                "filePath": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lastAccessAt": {
+                    "type": "string"
+                },
+                "passwordProtected": {
+                    "type": "boolean"
+                },
+                "urlPath": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -384,6 +384,60 @@ definitions:
       autoUpdate:
         type: boolean
     type: object
+  v1_shares.createShareRequest:
+    properties:
+      deviceSerial:
+        type: string
+      expiresInHours:
+        description: |-
+          ExpiresInHours, when > 0, sets the link expiry relative to now.
+          0 means the link never expires.
+        type: integer
+      filePath:
+        type: string
+      password:
+        description: Password, when non-empty, protects the link.
+        type: string
+    type: object
+  v1_shares.shareInfoJSON:
+    properties:
+      expiresAt:
+        type: string
+      isFolder:
+        type: boolean
+      name:
+        description: |-
+          Name and IsFolder are omitted until the password (if any) is supplied,
+          so a protected link leaks nothing about its target.
+        type: string
+      passwordProtected:
+        type: boolean
+      sizeBytes:
+        type: integer
+    type: object
+  v1_shares.shareJSON:
+    properties:
+      accessCount:
+        type: integer
+      createdAt:
+        type: string
+      deviceSerial:
+        type: string
+      expired:
+        type: boolean
+      expiresAt:
+        type: string
+      filePath:
+        type: string
+      id:
+        type: string
+      lastAccessAt:
+        type: string
+      passwordProtected:
+        type: boolean
+      urlPath:
+        type: string
+    type: object
   v1_version.SbomDependencyJSON:
     properties:
       path:
@@ -1746,6 +1800,80 @@ paths:
       summary: Save the rotation for a photo
       tags:
       - photos
+  /public/shares/{token}:
+    get:
+      description: Streams the shared file (folders are zipped). Always served as
+        an attachment with sniffing disabled so shared content can never execute in
+        the app's origin.
+      parameters:
+      - description: Share token
+        in: path
+        name: token
+        required: true
+        type: string
+      - description: Share password
+        in: query
+        name: password
+        type: string
+      produces:
+      - application/octet-stream
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: file
+        "401":
+          description: Password required
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "403":
+          description: Wrong password
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "410":
+          description: Gone (expired)
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: Download a shared file or folder (public)
+      tags:
+      - shares
+  /public/shares/{token}/info:
+    get:
+      description: Returns metadata about a share link. For password-protected shares
+        the target name and size are withheld until the correct password is supplied
+        via X-Share-Password or ?password=.
+      parameters:
+      - description: Share token
+        in: path
+        name: token
+        required: true
+        type: string
+      - description: Share password
+        in: query
+        name: password
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1_shares.shareInfoJSON'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "410":
+          description: Gone (expired)
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: Get share link metadata (public)
+      tags:
+      - shares
   /sbom:
     get:
       description: Returns the Go version and all embedded dependency information
@@ -1810,6 +1938,80 @@ paths:
       summary: Update settings
       tags:
       - settings
+  /shares:
+    get:
+      description: Returns all share links, newest first, including expired ones.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/v1_shares.shareJSON'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: List share links
+      tags:
+      - shares
+    post:
+      consumes:
+      - application/json
+      description: Creates a tokenized public link for a file or folder, optionally
+        password-protected and/or expiring.
+      parameters:
+      - description: Share definition
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/v1_shares.createShareRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1_shares.shareJSON'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: Create a public share link
+      tags:
+      - shares
+  /shares/{id}:
+    delete:
+      description: Deletes a share link by ID. The public URL stops working immediately.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/serverutil.Response'
+      summary: Revoke a share link
+      tags:
+      - shares
   /storage/devices/backup:
     post:
       description: Begin a backup to a device

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autobutler-org/autobutler
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0

--- a/internal/server/api/v1/shares/manage_shares.go
+++ b/internal/server/api/v1/shares/manage_shares.go
@@ -1,0 +1,159 @@
+package v1_shares
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
+	"github.com/autobutler-org/autobutler/pkg/util/deputil"
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
+	"github.com/autobutler-org/autobutler/pkg/util/shareutil"
+	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
+
+	"github.com/gin-gonic/gin"
+)
+
+// publicSharePathPrefix is where public share links are served. Kept in one
+// place so the URL returned to clients and the routes can't drift apart.
+const publicSharePathPrefix = "/api/v1/public/shares/"
+
+type createShareRequest struct {
+	FilePath     string `json:"filePath"`
+	DeviceSerial string `json:"deviceSerial"`
+	// Password, when non-empty, protects the link.
+	Password string `json:"password"`
+	// ExpiresInHours, when > 0, sets the link expiry relative to now.
+	// 0 means the link never expires.
+	ExpiresInHours int `json:"expiresInHours"`
+}
+
+type shareJSON struct {
+	ID                string     `json:"id"`
+	FilePath          string     `json:"filePath"`
+	DeviceSerial      string     `json:"deviceSerial,omitempty"`
+	URLPath           string     `json:"urlPath"`
+	PasswordProtected bool       `json:"passwordProtected"`
+	CreatedAt         time.Time  `json:"createdAt"`
+	ExpiresAt         *time.Time `json:"expiresAt,omitempty"`
+	Expired           bool       `json:"expired"`
+	AccessCount       int64      `json:"accessCount"`
+	LastAccessAt      *time.Time `json:"lastAccessAt,omitempty"`
+}
+
+// toShareJSON maps a share record to its API shape. The bcrypt hash never
+// leaves the server; the token only appears embedded in urlPath.
+func toShareJSON(s shareutil.Share) shareJSON {
+	return shareJSON{
+		ID:                s.ID,
+		FilePath:          s.FilePath,
+		DeviceSerial:      s.DeviceSerial,
+		URLPath:           publicSharePathPrefix + s.Token,
+		PasswordProtected: s.PasswordProtected(),
+		CreatedAt:         s.CreatedAt,
+		ExpiresAt:         s.ExpiresAt,
+		Expired:           s.IsExpired(),
+		AccessCount:       s.AccessCount,
+		LastAccessAt:      s.LastAccessAt,
+	}
+}
+
+// createShare godoc
+// @Summary Create a public share link
+// @Description Creates a tokenized public link for a file or folder, optionally password-protected and/or expiring.
+// @Tags shares
+// @Accept json
+// @Produce json
+// @Param body body createShareRequest true "Share definition"
+// @Success 200 {object} shareJSON
+// @Failure 400 {object} serverutil.Response "Bad Request"
+// @Failure 404 {object} serverutil.Response "Not Found"
+// @Failure 500 {object} serverutil.Response "Internal Server Error"
+// @Router /shares [post]
+func createShare(c *gin.Context) *serverutil.Response {
+	var req createShareRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		return serverutil.BadRequest(errors.New("invalid request body"))
+	}
+	if req.FilePath == "" {
+		return serverutil.BadRequest(errors.New("filePath is required"))
+	}
+	if req.ExpiresInHours < 0 {
+		return serverutil.BadRequest(errors.New("expiresInHours must not be negative"))
+	}
+
+	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")
+	if !ok {
+		return serverutil.InternalServerError(nil)
+	}
+
+	// Only existing paths can be shared — this also runs the safeJoin
+	// traversal guard before anything is persisted.
+	if _, err := deps.StorageService().StatFile(storageutil.StatFileParams{
+		FilePath:     req.FilePath,
+		DeviceSerial: req.DeviceSerial,
+	}); err != nil {
+		return serverutil.NotFound(fmt.Errorf("cannot share: %w", err))
+	}
+
+	var expiresAt *time.Time
+	if req.ExpiresInHours > 0 {
+		t := time.Now().UTC().Add(time.Duration(req.ExpiresInHours) * time.Hour)
+		expiresAt = &t
+	}
+
+	result, err := shareutil.Create(shareutil.CreateShareParams{
+		FilePath:     req.FilePath,
+		DeviceSerial: req.DeviceSerial,
+		Password:     req.Password,
+		ExpiresAt:    expiresAt,
+	})
+	if err != nil {
+		return serverutil.InternalServerError(err)
+	}
+	return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(toShareJSON(result.Share))
+}
+
+// listShares godoc
+// @Summary List share links
+// @Description Returns all share links, newest first, including expired ones.
+// @Tags shares
+// @Produce json
+// @Success 200 {array} shareJSON
+// @Failure 500 {object} serverutil.Response "Internal Server Error"
+// @Router /shares [get]
+func listShares(c *gin.Context) *serverutil.Response {
+	shares, err := shareutil.List()
+	if err != nil {
+		return serverutil.InternalServerError(err)
+	}
+	out := make([]shareJSON, 0, len(shares))
+	for _, s := range shares {
+		out = append(out, toShareJSON(s))
+	}
+	return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(out)
+}
+
+// deleteShare godoc
+// @Summary Revoke a share link
+// @Description Deletes a share link by ID. The public URL stops working immediately.
+// @Tags shares
+// @Produce json
+// @Success 200 {object} serverutil.Response
+// @Failure 404 {object} serverutil.Response "Not Found"
+// @Failure 500 {object} serverutil.Response "Internal Server Error"
+// @Router /shares/{id} [delete]
+func deleteShare(c *gin.Context) *serverutil.Response {
+	id := c.Param("id")
+	if err := shareutil.Delete(id); err != nil {
+		if errors.Is(err, shareutil.ErrNotFound) {
+			return serverutil.NotFound(err)
+		}
+		return serverutil.InternalServerError(err)
+	}
+	return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(gin.H{"deleted": id})
+}
+
+var createShareRoute = serverutil.ApiRoute("POST", "/shares", createShare)
+var listSharesRoute = serverutil.ApiRoute("GET", "/shares", listShares)
+var deleteShareRoute = serverutil.ApiRoute("DELETE", "/shares/:id", deleteShare)

--- a/internal/server/api/v1/shares/manage_shares.go
+++ b/internal/server/api/v1/shares/manage_shares.go
@@ -3,6 +3,8 @@ package v1_shares
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
@@ -77,6 +79,12 @@ func createShare(c *gin.Context) *serverutil.Response {
 	}
 	if req.FilePath == "" {
 		return serverutil.BadRequest(errors.New("filePath is required"))
+	}
+	// Mirror the re-validation on the public endpoints: paths containing ".."
+	// or absolute paths are rejected there, so refuse to create shares that
+	// could never be downloaded. (safeJoin below guards actual traversal.)
+	if strings.Contains(req.FilePath, "..") || filepath.IsAbs(req.FilePath) {
+		return serverutil.BadRequest(errors.New("filePath must be a relative path without '..'"))
 	}
 	if req.ExpiresInHours < 0 {
 		return serverutil.BadRequest(errors.New("expiresInHours must not be negative"))

--- a/internal/server/api/v1/shares/public_shares.go
+++ b/internal/server/api/v1/shares/public_shares.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/autobutler-org/autobutler/pkg/util/authutil"
 	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
@@ -84,6 +85,12 @@ func publicShareInfo(c *gin.Context) *serverutil.Response {
 	if err != nil {
 		return shareErrorResponse(err)
 	}
+	// Re-validate the stored path at the trust boundary: creation checks it
+	// and safeJoin guards resolution, but this route is unauthenticated and
+	// shares.json could in principle be edited by hand.
+	if strings.Contains(share.FilePath, "..") || filepath.IsAbs(share.FilePath) {
+		return serverutil.NotFound(errors.New("share not found"))
+	}
 
 	info := shareInfoJSON{PasswordProtected: share.PasswordProtected()}
 	if share.ExpiresAt != nil {
@@ -134,6 +141,10 @@ func publicShareDownload(c *gin.Context) *serverutil.Response {
 	share, err := shareutil.Resolve(c.Param("token"), suppliedPassword(c))
 	if err != nil {
 		return shareErrorResponse(err)
+	}
+	// Re-validate the stored path at the trust boundary (see publicShareInfo).
+	if strings.Contains(share.FilePath, "..") || filepath.IsAbs(share.FilePath) {
+		return serverutil.NotFound(errors.New("share not found"))
 	}
 
 	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")

--- a/internal/server/api/v1/shares/public_shares.go
+++ b/internal/server/api/v1/shares/public_shares.go
@@ -1,0 +1,174 @@
+package v1_shares
+
+import (
+	"archive/zip"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/autobutler-org/autobutler/pkg/util/authutil"
+	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
+	"github.com/autobutler-org/autobutler/pkg/util/deputil"
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
+	"github.com/autobutler-org/autobutler/pkg/util/shareutil"
+	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
+
+	"github.com/gin-gonic/gin"
+)
+
+// sharePasswordHeader carries the share password on public requests. A query
+// parameter (?password=) is also accepted for clients that cannot set headers,
+// e.g. a plain browser link.
+const sharePasswordHeader = "X-Share-Password"
+
+type shareInfoJSON struct {
+	// Name and IsFolder are omitted until the password (if any) is supplied,
+	// so a protected link leaks nothing about its target.
+	Name              string `json:"name,omitempty"`
+	IsFolder          bool   `json:"isFolder"`
+	SizeBytes         int64  `json:"sizeBytes,omitempty"`
+	PasswordProtected bool   `json:"passwordProtected"`
+	ExpiresAt         string `json:"expiresAt,omitempty"`
+}
+
+// suppliedPassword extracts the share password from header or query.
+func suppliedPassword(c *gin.Context) string {
+	if p := c.GetHeader(sharePasswordHeader); p != "" {
+		return p
+	}
+	return c.Query("password")
+}
+
+// shareErrorResponse maps shareutil sentinel errors onto HTTP semantics.
+// Unknown and expired shares are indistinguishable content-wise, but expired
+// links return 410 so recipients see "this link expired" rather than a 404.
+func shareErrorResponse(err error) *serverutil.Response {
+	switch {
+	case errors.Is(err, shareutil.ErrNotFound):
+		return serverutil.NotFound(errors.New("share not found"))
+	case errors.Is(err, shareutil.ErrExpired):
+		return serverutil.NewResponse().
+			WithContentType(serverutil.ContentTypeJSON).
+			WithStatusCode(http.StatusGone).
+			WithError(errors.New("share link has expired"))
+	case errors.Is(err, shareutil.ErrPasswordRequired):
+		return serverutil.NewResponse().
+			WithContentType(serverutil.ContentTypeJSON).
+			WithStatusCode(http.StatusUnauthorized).
+			WithError(errors.New("password required"))
+	case errors.Is(err, shareutil.ErrWrongPassword):
+		return serverutil.NewResponse().
+			WithContentType(serverutil.ContentTypeJSON).
+			WithStatusCode(http.StatusForbidden).
+			WithError(errors.New("wrong password"))
+	default:
+		return serverutil.InternalServerError(err)
+	}
+}
+
+// publicShareInfo godoc
+// @Summary Get share link metadata (public)
+// @Description Returns metadata about a share link. For password-protected shares the target name and size are withheld until the correct password is supplied via X-Share-Password or ?password=.
+// @Tags shares
+// @Produce json
+// @Param token path string true "Share token"
+// @Param password query string false "Share password"
+// @Success 200 {object} shareInfoJSON
+// @Failure 404 {object} serverutil.Response "Not Found"
+// @Failure 410 {object} serverutil.Response "Gone (expired)"
+// @Router /public/shares/{token}/info [get]
+func publicShareInfo(c *gin.Context) *serverutil.Response {
+	share, err := shareutil.Peek(c.Param("token"))
+	if err != nil {
+		return shareErrorResponse(err)
+	}
+
+	info := shareInfoJSON{PasswordProtected: share.PasswordProtected()}
+	if share.ExpiresAt != nil {
+		info.ExpiresAt = share.ExpiresAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	}
+
+	// Withhold target details until the password checks out.
+	if share.PasswordProtected() && !authutil.CheckPassword(suppliedPassword(c), share.PasswordHash) {
+		return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(info)
+	}
+
+	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")
+	if !ok {
+		return serverutil.InternalServerError(nil)
+	}
+	stat, err := deps.StorageService().StatFile(storageutil.StatFileParams{
+		FilePath:     share.FilePath,
+		DeviceSerial: share.DeviceSerial,
+	})
+	if err != nil {
+		// The underlying file was deleted or its device unplugged.
+		return serverutil.NotFound(errors.New("shared file is no longer available"))
+	}
+	info.Name = stat.Name
+	info.IsFolder = stat.IsDir
+	if !stat.IsDir {
+		if fi, err := os.Stat(stat.FullPath); err == nil {
+			info.SizeBytes = fi.Size()
+		}
+	}
+	return serverutil.Ok().WithContentType(serverutil.ContentTypeJSON).WithData(info)
+}
+
+// publicShareDownload godoc
+// @Summary Download a shared file or folder (public)
+// @Description Streams the shared file (folders are zipped). Always served as an attachment with sniffing disabled so shared content can never execute in the app's origin.
+// @Tags shares
+// @Produce application/octet-stream
+// @Param token path string true "Share token"
+// @Param password query string false "Share password"
+// @Success 200 {file} file
+// @Failure 401 {object} serverutil.Response "Password required"
+// @Failure 403 {object} serverutil.Response "Wrong password"
+// @Failure 404 {object} serverutil.Response "Not Found"
+// @Failure 410 {object} serverutil.Response "Gone (expired)"
+// @Router /public/shares/{token} [get]
+func publicShareDownload(c *gin.Context) *serverutil.Response {
+	share, err := shareutil.Resolve(c.Param("token"), suppliedPassword(c))
+	if err != nil {
+		return shareErrorResponse(err)
+	}
+
+	deps, ok := ctxutil.Get[deputil.Dependencies](c, "deps")
+	if !ok {
+		return serverutil.InternalServerError(nil)
+	}
+	result, err := deps.StorageService().DownloadFile(storageutil.DownloadFileParams{
+		FilePath:     share.FilePath,
+		DeviceSerial: share.DeviceSerial,
+	})
+	if err != nil {
+		return serverutil.NotFound(errors.New("shared file is no longer available"))
+	}
+
+	// Defense in depth: this endpoint is unauthenticated and serves
+	// user-chosen files on the app's origin, so never let the browser render
+	// or sniff the content — a shared .html file must not become stored XSS.
+	c.Header("X-Content-Type-Options", "nosniff")
+	c.Header("Content-Security-Policy", "sandbox")
+	c.Header("Content-Type", "application/octet-stream")
+
+	if result.IsFolder {
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(result.FullPath)+".zip"))
+		zipWriter := zip.NewWriter(c.Writer)
+		defer zipWriter.Close()
+		if err := zipWriter.AddFS(os.DirFS(result.FullPath)); err != nil {
+			return serverutil.InternalServerError(fmt.Errorf("failed to zip shared folder: %w", err))
+		}
+		return nil // response written directly to writer
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(result.FullPath)))
+	c.File(result.FullPath)
+	return nil // response written directly via c.File
+}
+
+var publicShareInfoRoute = serverutil.ApiRoute("GET", "/public/shares/:token/info", publicShareInfo)
+var publicShareDownloadRoute = serverutil.ApiRoute("GET", "/public/shares/:token", publicShareDownload)

--- a/internal/server/api/v1/shares/shares_test.go
+++ b/internal/server/api/v1/shares/shares_test.go
@@ -1,0 +1,301 @@
+package v1_shares_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v1_shares "github.com/autobutler-org/autobutler/internal/server/api/v1/shares"
+	"github.com/autobutler-org/autobutler/pkg/util/ctxutil"
+	"github.com/autobutler-org/autobutler/pkg/util/deputil"
+	"github.com/autobutler-org/autobutler/pkg/util/serverutil"
+	"github.com/autobutler-org/autobutler/pkg/util/shareutil"
+	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
+	"github.com/gin-gonic/gin"
+)
+
+// fakeDetector implements storageutil.Detector and returns a single internal
+// device pointing at the provided temp directory (same pattern as the cirrus
+// integration tests).
+type fakeDetector struct {
+	mountPoint string
+}
+
+func (f *fakeDetector) DetectDevices() ([]storageutil.Device, error) {
+	return []storageutil.Device{
+		{
+			Name:       "Test Device",
+			MountPoint: f.mountPoint,
+			IsInternal: true,
+		},
+	}, nil
+}
+
+// newTestEngine creates a gin engine with the shares routes registered, a
+// fake StorageService pointing at a temp cirrus dir, and the share store
+// pointed at a temp shares.json.
+func newTestEngine(t *testing.T) (*gin.Engine, string) {
+	t.Helper()
+
+	mountPoint := t.TempDir()
+	cirrusDir := filepath.Join(mountPoint, "autobutler", "data", "cirrus")
+	if err := os.MkdirAll(cirrusDir, 0755); err != nil {
+		t.Fatalf("failed to create cirrus dir: %v", err)
+	}
+
+	shareutil.ResetForTesting(filepath.Join(t.TempDir(), "shares.json"))
+	t.Cleanup(func() { shareutil.ResetForTesting("") })
+
+	svc := storageutil.NewStorageService(&fakeDetector{mountPoint: mountPoint})
+	deps := deputil.NewDependencies().WithStorageService(svc)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	engine.Use(func(c *gin.Context) {
+		c = ctxutil.With(c, "deps", deps)
+		c.Next()
+	})
+	group := engine.Group("/api/v1")
+	serverutil.RegisterRouterWithGroup(group, v1_shares.NewRouter())
+	return engine, cirrusDir
+}
+
+func doRequest(engine *gin.Engine, method, path string, body io.Reader) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, body)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	return w
+}
+
+// createShare posts a share definition and returns the parsed response.
+func createShare(t *testing.T, engine *gin.Engine, body map[string]any) map[string]any {
+	t.Helper()
+	payload, _ := json.Marshal(body)
+	w := doRequest(engine, http.MethodPost, "/api/v1/shares", bytes.NewReader(payload))
+	if w.Code != http.StatusOK {
+		t.Fatalf("create share returned %d: %s", w.Code, w.Body.String())
+	}
+	var share map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &share); err != nil {
+		t.Fatalf("failed to parse share response: %v", err)
+	}
+	return share
+}
+
+func writeTestFile(t *testing.T, cirrusDir, name, content string) {
+	t.Helper()
+	full := filepath.Join(cirrusDir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestShareLifecycle_File(t *testing.T) {
+	engine, cirrusDir := newTestEngine(t)
+	writeTestFile(t, cirrusDir, "docs/report.txt", "hello share")
+
+	share := createShare(t, engine, map[string]any{"filePath": "docs/report.txt"})
+	urlPath, _ := share["urlPath"].(string)
+	if urlPath == "" {
+		t.Fatal("expected urlPath in create response")
+	}
+
+	// Public info
+	w := doRequest(engine, http.MethodGet, urlPath+"/info", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("info returned %d: %s", w.Code, w.Body.String())
+	}
+	var info map[string]any
+	json.Unmarshal(w.Body.Bytes(), &info)
+	if info["name"] != "report.txt" || info["isFolder"] != false {
+		t.Errorf("unexpected info: %v", info)
+	}
+
+	// Public download
+	w = doRequest(engine, http.MethodGet, urlPath, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("download returned %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "hello share" {
+		t.Errorf("unexpected download body: %q", w.Body.String())
+	}
+	if got := w.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("expected nosniff, got %q", got)
+	}
+	if got := w.Header().Get("Content-Security-Policy"); got != "sandbox" {
+		t.Errorf("expected CSP sandbox, got %q", got)
+	}
+	if got := w.Header().Get("Content-Disposition"); got != `attachment; filename="report.txt"` {
+		t.Errorf("unexpected disposition: %q", got)
+	}
+
+	// List shows the share with access count
+	w = doRequest(engine, http.MethodGet, "/api/v1/shares", nil)
+	var shares []map[string]any
+	json.Unmarshal(w.Body.Bytes(), &shares)
+	if len(shares) != 1 {
+		t.Fatalf("expected 1 share, got %d", len(shares))
+	}
+	if shares[0]["accessCount"].(float64) != 1 {
+		t.Errorf("expected accessCount 1, got %v", shares[0]["accessCount"])
+	}
+	if _, leaked := shares[0]["passwordHash"]; leaked {
+		t.Error("passwordHash must not appear in API responses")
+	}
+
+	// Revoke, then the public link dies
+	id, _ := share["id"].(string)
+	w = doRequest(engine, http.MethodDelete, "/api/v1/shares/"+id, nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("delete returned %d: %s", w.Code, w.Body.String())
+	}
+	w = doRequest(engine, http.MethodGet, urlPath, nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 after revoke, got %d", w.Code)
+	}
+}
+
+func TestShareDownload_FolderZips(t *testing.T) {
+	engine, cirrusDir := newTestEngine(t)
+	writeTestFile(t, cirrusDir, "album/one.txt", "1")
+	writeTestFile(t, cirrusDir, "album/two.txt", "2")
+
+	share := createShare(t, engine, map[string]any{"filePath": "album"})
+	w := doRequest(engine, http.MethodGet, share["urlPath"].(string), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("folder download returned %d: %s", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Disposition"); got != `attachment; filename="album.zip"` {
+		t.Errorf("unexpected disposition: %q", got)
+	}
+	// Zip magic bytes
+	if body := w.Body.Bytes(); len(body) < 4 || body[0] != 'P' || body[1] != 'K' {
+		t.Error("expected zip content")
+	}
+}
+
+func TestShare_PasswordFlow(t *testing.T) {
+	engine, cirrusDir := newTestEngine(t)
+	writeTestFile(t, cirrusDir, "secret.txt", "classified")
+
+	share := createShare(t, engine, map[string]any{"filePath": "secret.txt", "password": "letmein1"})
+	urlPath := share["urlPath"].(string)
+
+	// No password → 401
+	w := doRequest(engine, http.MethodGet, urlPath, nil)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without password, got %d", w.Code)
+	}
+
+	// Wrong password → 403
+	req := httptest.NewRequest(http.MethodGet, urlPath, nil)
+	req.Header.Set("X-Share-Password", "wrong")
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 with wrong password, got %d", w.Code)
+	}
+
+	// Info without password must not leak the filename
+	w = doRequest(engine, http.MethodGet, urlPath+"/info", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("info returned %d", w.Code)
+	}
+	var info map[string]any
+	json.Unmarshal(w.Body.Bytes(), &info)
+	if name, ok := info["name"]; ok && name != "" {
+		t.Errorf("info must not leak name without password, got %v", name)
+	}
+	if info["passwordProtected"] != true {
+		t.Error("expected passwordProtected true")
+	}
+
+	// Correct password via header → content
+	req = httptest.NewRequest(http.MethodGet, urlPath, nil)
+	req.Header.Set("X-Share-Password", "letmein1")
+	w = httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+	if w.Code != http.StatusOK || w.Body.String() != "classified" {
+		t.Fatalf("expected content with correct password, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Correct password via query also works
+	w = doRequest(engine, http.MethodGet, urlPath+"?password=letmein1", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with query password, got %d", w.Code)
+	}
+}
+
+func TestShare_Expiry(t *testing.T) {
+	engine, cirrusDir := newTestEngine(t)
+	writeTestFile(t, cirrusDir, "old.txt", "stale")
+
+	// Create an already-expired share directly in the store.
+	past := time.Now().Add(-time.Minute)
+	res, err := shareutil.Create(shareutil.CreateShareParams{FilePath: "old.txt", ExpiresAt: &past})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := doRequest(engine, http.MethodGet, "/api/v1/public/shares/"+res.Share.Token, nil)
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410 for expired share, got %d", w.Code)
+	}
+	w = doRequest(engine, http.MethodGet, "/api/v1/public/shares/"+res.Share.Token+"/info", nil)
+	if w.Code != http.StatusGone {
+		t.Fatalf("expected 410 for expired info, got %d", w.Code)
+	}
+
+	// Expired shares still appear in the owner's list, flagged.
+	w = doRequest(engine, http.MethodGet, "/api/v1/shares", nil)
+	var shares []map[string]any
+	json.Unmarshal(w.Body.Bytes(), &shares)
+	if len(shares) != 1 || shares[0]["expired"] != true {
+		t.Errorf("expected one expired share in list, got %v", shares)
+	}
+}
+
+func TestCreateShare_Validation(t *testing.T) {
+	engine, cirrusDir := newTestEngine(t)
+	writeTestFile(t, cirrusDir, "real.txt", "x")
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"missing filePath", map[string]any{}, http.StatusBadRequest},
+		{"negative expiry", map[string]any{"filePath": "real.txt", "expiresInHours": -1}, http.StatusBadRequest},
+		{"nonexistent file", map[string]any{"filePath": "ghost.txt"}, http.StatusNotFound},
+		{"traversal", map[string]any{"filePath": "../../etc/passwd"}, http.StatusNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, _ := json.Marshal(tc.body)
+			w := doRequest(engine, http.MethodPost, "/api/v1/shares", bytes.NewReader(payload))
+			if w.Code != tc.want {
+				t.Errorf("expected %d, got %d: %s", tc.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestPublicShare_UnknownToken(t *testing.T) {
+	engine, _ := newTestEngine(t)
+	w := doRequest(engine, http.MethodGet, "/api/v1/public/shares/doesnotexist", nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}

--- a/internal/server/api/v1/shares/shares_test.go
+++ b/internal/server/api/v1/shares/shares_test.go
@@ -279,7 +279,8 @@ func TestCreateShare_Validation(t *testing.T) {
 		{"missing filePath", map[string]any{}, http.StatusBadRequest},
 		{"negative expiry", map[string]any{"filePath": "real.txt", "expiresInHours": -1}, http.StatusBadRequest},
 		{"nonexistent file", map[string]any{"filePath": "ghost.txt"}, http.StatusNotFound},
-		{"traversal", map[string]any{"filePath": "../../etc/passwd"}, http.StatusNotFound},
+		{"traversal", map[string]any{"filePath": "../../etc/passwd"}, http.StatusBadRequest},
+		{"absolute path", map[string]any{"filePath": "/etc/passwd"}, http.StatusBadRequest},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -297,5 +298,24 @@ func TestPublicShare_UnknownToken(t *testing.T) {
 	w := doRequest(engine, http.MethodGet, "/api/v1/public/shares/doesnotexist", nil)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPublicShare_RejectsTamperedStorePath(t *testing.T) {
+	engine, _ := newTestEngine(t)
+
+	// Simulate a hand-edited shares.json containing a traversal path — the
+	// public endpoints must reject it before touching the filesystem.
+	res, err := shareutil.Create(shareutil.CreateShareParams{FilePath: "../../etc/passwd"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := doRequest(engine, http.MethodGet, "/api/v1/public/shares/"+res.Share.Token, nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for tampered path on download, got %d", w.Code)
+	}
+	w = doRequest(engine, http.MethodGet, "/api/v1/public/shares/"+res.Share.Token+"/info", nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for tampered path on info, got %d", w.Code)
 	}
 }

--- a/internal/server/api/v1/shares/v1_shares.go
+++ b/internal/server/api/v1/shares/v1_shares.go
@@ -1,0 +1,23 @@
+// Package v1_shares implements public share links (issue #1338): authenticated
+// management endpoints under /shares, and unauthenticated access endpoints
+// under /public/shares/:token. The /api/v1/public/ prefix is exempted from
+// session auth in the middleware and rate-limited per IP.
+package v1_shares
+
+import "github.com/autobutler-org/autobutler/pkg/util/serverutil"
+
+type router struct{}
+
+func NewRouter() serverutil.Router {
+	return &router{}
+}
+
+func (r *router) Routes() []*serverutil.Route {
+	return []*serverutil.Route{
+		createShareRoute,
+		listSharesRoute,
+		deleteShareRoute,
+		publicShareInfoRoute,
+		publicShareDownloadRoute,
+	}
+}

--- a/internal/server/middleware/middleware.go
+++ b/internal/server/middleware/middleware.go
@@ -59,7 +59,10 @@ func rateLimit() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		if !authRateLimitedPaths[path] {
+		// Public share endpoints are unauthenticated, so they get the same
+		// per-IP limiter as the auth endpoints (also throttles guessing at
+		// share passwords, on top of bcrypt's per-attempt cost).
+		if !authRateLimitedPaths[path] && !strings.HasPrefix(path, publicSharePrefix) {
 			c.Next()
 			return
 		}
@@ -79,6 +82,11 @@ var authExemptPaths = map[string]bool{
 	"/api/v1/auth/recover": true,
 	"/api/v1/auth/status":  true,
 }
+
+// publicSharePrefix is the public share-link namespace. Requests under it are
+// authenticated by the share token itself (validated in the shares handlers),
+// not by a session — recipients of a share link have no account.
+const publicSharePrefix = "/api/v1/public/shares/"
 
 func inject(deps deputil.Dependencies) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -137,7 +145,7 @@ func requireAuth(deps deputil.Dependencies) gin.HandlerFunc {
 			return
 		}
 
-		if authExemptPaths[path] {
+		if authExemptPaths[path] || strings.HasPrefix(path, publicSharePrefix) {
 			c.Next()
 			return
 		}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -17,6 +17,7 @@ import (
 	v1_migration "github.com/autobutler-org/autobutler/internal/server/api/v1/migration"
 	v1_photos "github.com/autobutler-org/autobutler/internal/server/api/v1/photos"
 	v1_settings "github.com/autobutler-org/autobutler/internal/server/api/v1/settings"
+	v1_shares "github.com/autobutler-org/autobutler/internal/server/api/v1/shares"
 	v1_smb "github.com/autobutler-org/autobutler/internal/server/api/v1/smb"
 	v1_storage "github.com/autobutler-org/autobutler/internal/server/api/v1/storage"
 	v1_thumbnails "github.com/autobutler-org/autobutler/internal/server/api/v1/thumbnails"
@@ -55,6 +56,7 @@ func setupRouters(engine *gin.Engine, systemCollector *system.Collector) {
 		v1_favorites.NewRouter(),
 		v1_photos.NewRouter(),
 		v1_settings.NewRouter(),
+		v1_shares.NewRouter(),
 		v1_storage.NewRouter(),
 		v1_thumbnails.NewRouter(),
 		v1_smb.NewRouter(),

--- a/lib/controllers/file_browser_controller.dart
+++ b/lib/controllers/file_browser_controller.dart
@@ -251,6 +251,10 @@ class FileBrowserController {
           message: 'Extraction complete',
           shouldRefresh: true,
         );
+      case FileMenuAction.share:
+        // Handled in FileBrowserPage before reaching the controller (opens
+        // the share-link dialog); should never reach handleFileAction.
+        return null;
       case FileMenuAction.navigateToFolder:
         // Handled via the onNavigateToFolder callback in FileBrowserView;
         // should never reach handleFileAction.
@@ -264,6 +268,8 @@ class FileBrowserController {
         return 'Download failed';
       case FileMenuAction.moveRename:
         return 'Move/Rename failed';
+      case FileMenuAction.share:
+        return 'Share failed';
       case FileMenuAction.delete:
         return 'Delete failed';
       case FileMenuAction.extractHere:

--- a/lib/pages/file_browser_page.dart
+++ b/lib/pages/file_browser_page.dart
@@ -29,6 +29,7 @@ import 'package:autobutler/widgets/file_browser/file_storage_footer.dart';
 import 'package:autobutler/widgets/file_browser/file_top_bar.dart';
 import 'package:autobutler/widgets/file_browser/new_file_dialog.dart';
 import 'package:autobutler/widgets/file_browser/recent_files_section.dart';
+import 'package:autobutler/widgets/share_link_dialog.dart';
 import 'package:data_table/data_sheet.dart';
 import 'package:data_table/data_table.dart' as dt;
 import 'package:desktop_drop/desktop_drop.dart';
@@ -736,6 +737,17 @@ class _FileBrowserPageState extends State<FileBrowserPage>
       } catch (_) {
         if (mounted) _showMessage('Download failed');
       }
+      return;
+    }
+
+    // Share: open the link dialog — no cache mutation involved.
+    if (action == FileMenuAction.share) {
+      await showShareLinkDialog(
+        context,
+        filePath: node.apiPath,
+        displayName: trimTrailingSlashes(node.name),
+        serial: serialOrNull(node.deviceSerial),
+      );
       return;
     }
 

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -14,6 +14,7 @@ import 'package:autobutler/widgets/autobutler_drawer.dart';
 import 'package:autobutler/widgets/core/copy_button.dart';
 import 'package:autobutler/widgets/layout/autobutler_app_bar.dart';
 import 'package:autobutler/widgets/refresh_icon_button.dart';
+import 'package:autobutler/widgets/share_links_card.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:autobutler_icons/autobutler_icons.dart';
@@ -1171,6 +1172,12 @@ class _SettingsPageState extends State<SettingsPage> {
                 ],
               ),
             ),
+          const SizedBox(height: 24),
+
+          const _InfoSectionHeader(label: 'Share Links'),
+          const SizedBox(height: 8),
+          const ShareLinksCard(),
+
           const SizedBox(height: 24),
 
           const _InfoSectionHeader(label: 'Network Drive'),

--- a/lib/services/share_service.dart
+++ b/lib/services/share_service.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+
+import 'package:autobutler/services/app_settings.dart';
+import 'package:autobutler/services/authenticated_service.dart';
+import 'package:flutter/foundation.dart';
+
+/// One public share link as returned by the /shares API.
+class ShareLink {
+  const ShareLink({
+    required this.id,
+    required this.filePath,
+    required this.urlPath,
+    required this.passwordProtected,
+    required this.expired,
+    required this.accessCount,
+    this.deviceSerial = '',
+    this.expiresAt,
+    this.lastAccessAt,
+  });
+
+  final String id;
+  final String filePath;
+  final String deviceSerial;
+
+  /// Server-relative public URL, e.g. `/api/v1/public/shares/(token)`.
+  final String urlPath;
+  final bool passwordProtected;
+  final bool expired;
+  final int accessCount;
+  final DateTime? expiresAt;
+  final DateTime? lastAccessAt;
+
+  factory ShareLink.fromJson(Map<String, dynamic> json) => ShareLink(
+    id: json['id'] as String? ?? '',
+    filePath: json['filePath'] as String? ?? '',
+    deviceSerial: json['deviceSerial'] as String? ?? '',
+    urlPath: json['urlPath'] as String? ?? '',
+    passwordProtected: json['passwordProtected'] as bool? ?? false,
+    expired: json['expired'] as bool? ?? false,
+    accessCount: (json['accessCount'] as num?)?.toInt() ?? 0,
+    expiresAt: json['expiresAt'] != null
+        ? DateTime.tryParse(json['expiresAt'] as String)
+        : null,
+    lastAccessAt: json['lastAccessAt'] != null
+        ? DateTime.tryParse(json['lastAccessAt'] as String)
+        : null,
+  );
+
+  /// Absolute URL a recipient can open, based on the configured host (or the
+  /// web app's own origin as a fallback).
+  String get fullUrl => '${ShareService.publicBaseUrl()}$urlPath';
+}
+
+class ShareService with AuthenticatedService {
+  static final ShareService _instance = ShareService._();
+  ShareService._();
+  static ShareService get instance => _instance;
+
+  static Uri _apiUri(String path) {
+    final configured = AppSettings.instance.activeHost;
+    final base =
+        configured ??
+        String.fromEnvironment(
+          'API_BASE_URL',
+          defaultValue: 'http://localhost:8080',
+        );
+    final uri = Uri.parse(base);
+    final isLoopbackHost =
+        uri.host == 'localhost' || uri.host == '127.0.0.1' || uri.host == '::1';
+    Uri resolved;
+    if (!kIsWeb &&
+        defaultTargetPlatform == TargetPlatform.android &&
+        isLoopbackHost) {
+      resolved = uri.replace(host: '10.0.2.2');
+    } else {
+      resolved = uri;
+    }
+    return resolved.resolve('/api/v1$path');
+  }
+
+  /// Base URL used when handing a link to a recipient. Unlike [_apiUri], no
+  /// Android-emulator loopback rewrite — the link is for someone else's
+  /// device, not this app.
+  static String publicBaseUrl() {
+    final configured = AppSettings.instance.activeHost;
+    if (configured != null && configured.isNotEmpty) {
+      return configured.replaceAll(RegExp(r'/+$'), '');
+    }
+    if (kIsWeb) return Uri.base.origin;
+    return const String.fromEnvironment(
+      'API_BASE_URL',
+      defaultValue: 'http://localhost:8080',
+    );
+  }
+
+  /// Creates a share link for [filePath]. [expiresInHours] of 0 means the
+  /// link never expires; a non-empty [password] protects it.
+  static Future<ShareLink> create({
+    required String filePath,
+    String? serial,
+    int expiresInHours = 0,
+    String password = '',
+  }) async {
+    final response = await instance.authenticatedPost(
+      _apiUri('/shares'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({
+        'filePath': filePath,
+        'deviceSerial': serial ?? '',
+        'expiresInHours': expiresInHours,
+        'password': password,
+      }),
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Failed to create share link: ${response.statusCode}');
+    }
+    return ShareLink.fromJson(
+      json.decode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  /// Returns all share links, newest first.
+  static Future<List<ShareLink>> list() async {
+    final response = await instance.authenticatedGet(_apiUri('/shares'));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load share links: ${response.statusCode}');
+    }
+    final decoded = json.decode(response.body) as List<dynamic>;
+    return decoded
+        .map((item) => ShareLink.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Revokes a share link. The public URL stops working immediately.
+  static Future<void> revoke(String id) async {
+    final response = await instance.authenticatedDelete(_apiUri('/shares/$id'));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to revoke share link: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/widgets/file_browser/file_browser_view.dart
+++ b/lib/widgets/file_browser/file_browser_view.dart
@@ -13,6 +13,7 @@ import 'package:shimmer/shimmer.dart';
 
 enum FileMenuAction {
   download,
+  share,
   moveRename,
   delete,
   navigateToFolder,
@@ -297,6 +298,16 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                   ),
                   if (!widget.inArchive)
                     PopupMenuItem<FileMenuAction>(
+                      value: FileMenuAction.share,
+                      onTap: () => _dispatchMenuAction(
+                        context,
+                        item,
+                        FileMenuAction.share,
+                      ),
+                      child: const Text('Share link'),
+                    ),
+                  if (!widget.inArchive)
+                    PopupMenuItem<FileMenuAction>(
                       value: FileMenuAction.moveRename,
                       onTap: () => _dispatchMenuAction(
                         context,
@@ -553,6 +564,16 @@ class _FileBrowserViewState extends State<FileBrowserView> {
                                             ),
                                             child: const Text('Download'),
                                           ),
+                                          if (!widget.inArchive)
+                                            PopupMenuItem<FileMenuAction>(
+                                              value: FileMenuAction.share,
+                                              onTap: () => _dispatchMenuAction(
+                                                context,
+                                                item,
+                                                FileMenuAction.share,
+                                              ),
+                                              child: const Text('Share link'),
+                                            ),
                                           if (!widget.inArchive)
                                             PopupMenuItem<FileMenuAction>(
                                               value: FileMenuAction.moveRename,

--- a/lib/widgets/share_link_dialog.dart
+++ b/lib/widgets/share_link_dialog.dart
@@ -1,0 +1,197 @@
+import 'package:autobutler/services/share_service.dart';
+import 'package:autobutler/utils/autobutler_widget.dart';
+import 'package:autobutler_icons/autobutler_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Expiry choices offered when creating a share link. Hours of 0 = never.
+const _expiryOptions = <(String, int)>[
+  ('1 hour', 1),
+  ('1 day', 24),
+  ('7 days', 24 * 7),
+  ('30 days', 24 * 30),
+  ('Never', 0),
+];
+
+/// Shows the share-link creation dialog for [filePath]. On success the dialog
+/// switches to showing the generated link with a copy button.
+Future<void> showShareLinkDialog(
+  BuildContext context, {
+  required String filePath,
+  required String displayName,
+  String? serial,
+}) {
+  return AutobutlerWidget.showDialog<void>(
+    context,
+    useRootNavigator: true,
+    barrierDismissible: true,
+    builder: (context) => _ShareLinkDialog(
+      filePath: filePath,
+      displayName: displayName,
+      serial: serial,
+    ),
+  );
+}
+
+class _ShareLinkDialog extends StatefulWidget {
+  const _ShareLinkDialog({
+    required this.filePath,
+    required this.displayName,
+    this.serial,
+  });
+
+  final String filePath;
+  final String displayName;
+  final String? serial;
+
+  @override
+  State<_ShareLinkDialog> createState() => _ShareLinkDialogState();
+}
+
+class _ShareLinkDialogState extends State<_ShareLinkDialog> {
+  final _passwordController = TextEditingController();
+  int _expiresInHours = 24 * 7;
+  bool _creating = false;
+  String? _error;
+  ShareLink? _created;
+  bool _copied = false;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _create() async {
+    setState(() {
+      _creating = true;
+      _error = null;
+    });
+    try {
+      final link = await ShareService.create(
+        filePath: widget.filePath,
+        serial: widget.serial,
+        expiresInHours: _expiresInHours,
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      setState(() => _created = link);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _error = 'Failed to create share link');
+    } finally {
+      if (mounted) setState(() => _creating = false);
+    }
+  }
+
+  Future<void> _copyLink() async {
+    final link = _created;
+    if (link == null) return;
+    await Clipboard.setData(ClipboardData(text: link.fullUrl));
+    if (!mounted) return;
+    setState(() => _copied = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final created = _created;
+    return AlertDialog(
+      title: Text(
+        created == null ? 'Share "${widget.displayName}"' : 'Link created',
+      ),
+      content: created == null ? _buildForm() : _buildResult(created),
+      actions: created == null
+          ? [
+              TextButton(
+                onPressed: _creating ? null : () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: _creating ? null : _create,
+                child: _creating
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create link'),
+              ),
+            ]
+          : [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Done'),
+              ),
+            ],
+    );
+  }
+
+  Widget _buildForm() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Anyone with the link can download this item.'),
+        const SizedBox(height: 16),
+        DropdownButtonFormField<int>(
+          initialValue: _expiresInHours,
+          decoration: const InputDecoration(labelText: 'Expires'),
+          items: _expiryOptions
+              .map(
+                (option) => DropdownMenuItem<int>(
+                  value: option.$2,
+                  child: Text(option.$1),
+                ),
+              )
+              .toList(),
+          onChanged: (value) =>
+              setState(() => _expiresInHours = value ?? _expiresInHours),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _passwordController,
+          obscureText: true,
+          decoration: const InputDecoration(
+            labelText: 'Password (optional)',
+            hintText: 'Leave empty for no password',
+          ),
+        ),
+        if (_error != null) ...[
+          const SizedBox(height: 12),
+          Text(
+            _error!,
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildResult(ShareLink link) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SelectableText(link.fullUrl),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: OutlinedButton.icon(
+            onPressed: _copyLink,
+            icon: Icon(
+              _copied ? AutobutlerIcons.check : AutobutlerIcons.content_copy,
+            ),
+            label: Text(_copied ? 'Copied' : 'Copy link'),
+          ),
+        ),
+        if (link.passwordProtected) ...[
+          const SizedBox(height: 12),
+          const Text(
+            'Remember to send the password separately.',
+            style: TextStyle(fontSize: 12),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/widgets/share_links_card.dart
+++ b/lib/widgets/share_links_card.dart
@@ -1,0 +1,186 @@
+import 'package:autobutler/services/share_service.dart';
+import 'package:autobutler/widgets/refresh_icon_button.dart';
+import 'package:autobutler_icons/autobutler_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Settings-page card listing all public share links with copy and revoke
+/// actions. Self-contained: loads its own data via [ShareService].
+class ShareLinksCard extends StatefulWidget {
+  const ShareLinksCard({super.key});
+
+  @override
+  State<ShareLinksCard> createState() => _ShareLinksCardState();
+}
+
+class _ShareLinksCardState extends State<ShareLinksCard> {
+  List<ShareLink> _shares = [];
+  bool _isLoading = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final shares = await ShareService.list();
+      if (!mounted) return;
+      setState(() {
+        _shares = shares;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _revoke(ShareLink share) async {
+    try {
+      await ShareService.revoke(share.id);
+      await _load();
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Failed to revoke share link')),
+      );
+    }
+  }
+
+  Future<void> _copy(ShareLink share) async {
+    await Clipboard.setData(ClipboardData(text: share.fullUrl));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Link copied')));
+  }
+
+  String _subtitle() {
+    if (_isLoading) return 'Loading...';
+    if (_error != null) return 'Failed to load share links';
+    if (_shares.isEmpty) return 'No active share links';
+    final active = _shares.where((s) => !s.expired).length;
+    return '$active active link${active == 1 ? '' : 's'}';
+  }
+
+  String _shareDetails(ShareLink share) {
+    final parts = <String>[];
+    if (share.expired) {
+      parts.add('expired');
+    } else if (share.expiresAt != null) {
+      parts.add('expires ${_formatRelative(share.expiresAt!)}');
+    } else {
+      parts.add('never expires');
+    }
+    if (share.passwordProtected) parts.add('password');
+    parts.add(
+      '${share.accessCount} download${share.accessCount == 1 ? '' : 's'}',
+    );
+    return parts.join(' · ');
+  }
+
+  String _formatRelative(DateTime dt) {
+    final diff = dt.difference(DateTime.now());
+    if (diff.isNegative) return 'now';
+    if (diff.inMinutes < 60) return 'in ${diff.inMinutes}m';
+    if (diff.inHours < 24) return 'in ${diff.inHours}h';
+    return 'in ${diff.inDays}d';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ExpansionTile(
+        title: const Text(
+          'Share links',
+          style: TextStyle(fontWeight: FontWeight.w600),
+        ),
+        subtitle: Text(_subtitle()),
+        children: [
+          Align(
+            alignment: Alignment.centerRight,
+            child: Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: RefreshIconButton(
+                isRefreshing: _isLoading,
+                onPressed: _load,
+                tooltip: 'Refresh share links',
+              ),
+            ),
+          ),
+          if (_isLoading)
+            const Padding(
+              padding: EdgeInsets.all(8),
+              child: Center(
+                child: SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+              ),
+            )
+          else if (_error != null)
+            ListTile(
+              leading: Icon(
+                AutobutlerIcons.error_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: const Text('Failed to load share links'),
+              subtitle: Text(_error!),
+            )
+          else if (_shares.isEmpty)
+            const ListTile(
+              title: Text('No share links yet'),
+              subtitle: Text(
+                'Share a file from the file browser to create one.',
+              ),
+            )
+          else
+            ..._shares.map(
+              (share) => ListTile(
+                leading: Icon(
+                  share.expired
+                      ? AutobutlerIcons.link_off
+                      : AutobutlerIcons.link_outlined,
+                ),
+                title: Text(
+                  share.filePath,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(
+                  _shareDetails(share),
+                  style: const TextStyle(fontSize: 12),
+                ),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(AutobutlerIcons.content_copy),
+                      tooltip: 'Copy link',
+                      onPressed: share.expired ? null : () => _copy(share),
+                    ),
+                    IconButton(
+                      icon: const Icon(AutobutlerIcons.delete_outline),
+                      tooltip: 'Revoke',
+                      onPressed: () => _revoke(share),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/pkg/util/shareutil/shareutil.go
+++ b/pkg/util/shareutil/shareutil.go
@@ -1,0 +1,280 @@
+// Package shareutil manages public share links: tokenized, optionally
+// password-protected, optionally expiring links to files or folders in the
+// cirrus directory. Shares are persisted as a JSON file in the data directory
+// (see AGENTS.md — the database is a last resort; a small rebuildable JSON
+// file is sufficient here).
+package shareutil
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/autobutler-org/autobutler/pkg/util/authutil"
+	"github.com/autobutler-org/autobutler/pkg/util/storageutil"
+)
+
+const sharesFileName = "shares.json"
+
+// Sentinel errors returned by Resolve. The HTTP layer maps these to status
+// codes (404 / 410 / 401 / 403 respectively).
+var (
+	ErrNotFound         = errors.New("share not found")
+	ErrExpired          = errors.New("share expired")
+	ErrPasswordRequired = errors.New("share password required")
+	ErrWrongPassword    = errors.New("wrong share password")
+)
+
+// Share is one public share link record.
+type Share struct {
+	ID           string     `json:"id"`
+	Token        string     `json:"token"`
+	FilePath     string     `json:"filePath"`
+	DeviceSerial string     `json:"deviceSerial,omitempty"`
+	PasswordHash string     `json:"passwordHash,omitempty"`
+	CreatedAt    time.Time  `json:"createdAt"`
+	ExpiresAt    *time.Time `json:"expiresAt,omitempty"`
+	AccessCount  int64      `json:"accessCount"`
+	LastAccessAt *time.Time `json:"lastAccessAt,omitempty"`
+}
+
+// IsExpired reports whether the share's expiry (if any) has passed.
+func (s *Share) IsExpired() bool {
+	return s.ExpiresAt != nil && time.Now().After(*s.ExpiresAt)
+}
+
+// PasswordProtected reports whether the share requires a password.
+func (s *Share) PasswordProtected() bool {
+	return s.PasswordHash != ""
+}
+
+var (
+	mu           sync.Mutex
+	cached       []Share
+	loaded       bool
+	pathOverride string // set by ResetForTesting only
+)
+
+func sharesPath() string {
+	if pathOverride != "" {
+		return pathOverride
+	}
+	return filepath.Join(storageutil.GetDataDir(), sharesFileName)
+}
+
+// ResetForTesting points the store at a test-specific file and drops the
+// in-process cache. Pass "" to restore the default path.
+func ResetForTesting(path string) {
+	mu.Lock()
+	defer mu.Unlock()
+	pathOverride = path
+	cached = nil
+	loaded = false
+}
+
+// load reads shares from disk into the cache. Caller must hold mu.
+func load() error {
+	if loaded {
+		return nil
+	}
+	data, err := os.ReadFile(sharesPath())
+	if os.IsNotExist(err) {
+		cached = nil
+		loaded = true
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read shares file: %w", err)
+	}
+	var shares []Share
+	if err := json.Unmarshal(data, &shares); err != nil {
+		return fmt.Errorf("failed to parse shares file: %w", err)
+	}
+	cached = shares
+	loaded = true
+	return nil
+}
+
+// save writes the cache to disk atomically (temp file + rename). The file is
+// 0600 because it contains share tokens and password hashes. Caller must hold mu.
+func save() error {
+	path := sharesPath()
+	data, err := json.MarshalIndent(cached, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal shares: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("failed to write shares file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("failed to replace shares file: %w", err)
+	}
+	return nil
+}
+
+// CreateShareParams contains parameters for creating a share link.
+type CreateShareParams struct {
+	// FilePath is the cirrus-relative path of the file or folder to share.
+	FilePath     string
+	DeviceSerial string
+	// Password, when non-empty, protects the share (stored as a bcrypt hash).
+	Password string
+	// ExpiresAt, when non-nil, is the moment the share stops working.
+	ExpiresAt *time.Time
+}
+
+// CreateShareResult contains the newly created share.
+type CreateShareResult struct {
+	Share Share
+}
+
+// Create generates a new share link. The caller is responsible for having
+// validated that FilePath exists (see StorageService.StatFile).
+func Create(params CreateShareParams) (*CreateShareResult, error) {
+	if params.FilePath == "" {
+		return nil, fmt.Errorf("filePath is required")
+	}
+
+	token, err := authutil.GenerateSessionToken()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate share token: %w", err)
+	}
+	idBytes := make([]byte, 8)
+	if _, err := rand.Read(idBytes); err != nil {
+		return nil, fmt.Errorf("failed to generate share id: %w", err)
+	}
+
+	share := Share{
+		ID:           hex.EncodeToString(idBytes),
+		Token:        token,
+		FilePath:     params.FilePath,
+		DeviceSerial: params.DeviceSerial,
+		CreatedAt:    time.Now().UTC(),
+		ExpiresAt:    params.ExpiresAt,
+	}
+	if params.Password != "" {
+		hash, err := authutil.HashPassword(params.Password)
+		if err != nil {
+			return nil, err
+		}
+		share.PasswordHash = hash
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if err := load(); err != nil {
+		return nil, err
+	}
+	cached = append(cached, share)
+	if err := save(); err != nil {
+		return nil, err
+	}
+	return &CreateShareResult{Share: share}, nil
+}
+
+// List returns all shares, newest first.
+func List() ([]Share, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if err := load(); err != nil {
+		return nil, err
+	}
+	out := make([]Share, len(cached))
+	copy(out, cached)
+	// Newest first — cached is append-ordered.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out, nil
+}
+
+// Delete removes a share by ID. Returns ErrNotFound if no share has that ID.
+func Delete(id string) error {
+	mu.Lock()
+	defer mu.Unlock()
+	if err := load(); err != nil {
+		return err
+	}
+	for i, s := range cached {
+		if s.ID == id {
+			cached = append(cached[:i], cached[i+1:]...)
+			return save()
+		}
+	}
+	return ErrNotFound
+}
+
+// Resolve looks up a share by token and validates expiry and password.
+// On success it records the access (count + timestamp) and returns a copy of
+// the share. Password checking uses bcrypt via authutil.
+func Resolve(token, password string) (*Share, error) {
+	if token == "" {
+		return nil, ErrNotFound
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if err := load(); err != nil {
+		return nil, err
+	}
+	for i := range cached {
+		s := &cached[i]
+		if s.Token != token {
+			continue
+		}
+		if s.IsExpired() {
+			return nil, ErrExpired
+		}
+		if s.PasswordProtected() {
+			if password == "" {
+				return nil, ErrPasswordRequired
+			}
+			if !authutil.CheckPassword(password, s.PasswordHash) {
+				return nil, ErrWrongPassword
+			}
+		}
+		now := time.Now().UTC()
+		s.AccessCount++
+		s.LastAccessAt = &now
+		// Best-effort: access bookkeeping should never block a download.
+		if err := save(); err != nil {
+			slog.Warn("shareutil: failed to record share access", "err", err)
+		}
+		out := *s
+		return &out, nil
+	}
+	return nil, ErrNotFound
+}
+
+// Peek looks up a share by token without password validation or access
+// bookkeeping. Used by the public info endpoint, which must be able to tell
+// a client that a password is required before it has one. Expired shares
+// still return ErrExpired so links die consistently across endpoints.
+func Peek(token string) (*Share, error) {
+	if token == "" {
+		return nil, ErrNotFound
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if err := load(); err != nil {
+		return nil, err
+	}
+	for i := range cached {
+		if cached[i].Token == token {
+			if cached[i].IsExpired() {
+				return nil, ErrExpired
+			}
+			out := cached[i]
+			return &out, nil
+		}
+	}
+	return nil, ErrNotFound
+}

--- a/pkg/util/shareutil/shareutil_test.go
+++ b/pkg/util/shareutil/shareutil_test.go
@@ -1,0 +1,159 @@
+package shareutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// useTempStore points the package at a temp shares.json and restores the
+// default path when the test finishes.
+func useTempStore(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "shares.json")
+	ResetForTesting(path)
+	t.Cleanup(func() { ResetForTesting("") })
+	return path
+}
+
+func TestCreateAndResolve(t *testing.T) {
+	useTempStore(t)
+
+	res, err := Create(CreateShareParams{FilePath: "docs/report.pdf", DeviceSerial: "abc"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if res.Share.Token == "" || res.Share.ID == "" {
+		t.Fatal("expected non-empty token and id")
+	}
+
+	got, err := Resolve(res.Share.Token, "")
+	if err != nil {
+		t.Fatalf("Resolve failed: %v", err)
+	}
+	if got.FilePath != "docs/report.pdf" || got.DeviceSerial != "abc" {
+		t.Errorf("unexpected share: %+v", got)
+	}
+	if got.AccessCount != 1 || got.LastAccessAt == nil {
+		t.Errorf("expected access bookkeeping, got count=%d last=%v", got.AccessCount, got.LastAccessAt)
+	}
+}
+
+func TestCreate_RequiresFilePath(t *testing.T) {
+	useTempStore(t)
+	if _, err := Create(CreateShareParams{}); err == nil {
+		t.Fatal("expected error for empty filePath")
+	}
+}
+
+func TestResolve_UnknownToken(t *testing.T) {
+	useTempStore(t)
+	if _, err := Resolve("nope", ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if _, err := Resolve("", ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound for empty token, got %v", err)
+	}
+}
+
+func TestResolve_Expired(t *testing.T) {
+	useTempStore(t)
+	past := time.Now().Add(-time.Hour)
+	res, err := Create(CreateShareParams{FilePath: "a.txt", ExpiresAt: &past})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if _, err := Resolve(res.Share.Token, ""); !errors.Is(err, ErrExpired) {
+		t.Fatalf("expected ErrExpired, got %v", err)
+	}
+	if _, err := Peek(res.Share.Token); !errors.Is(err, ErrExpired) {
+		t.Fatalf("expected ErrExpired from Peek, got %v", err)
+	}
+}
+
+func TestResolve_PasswordFlow(t *testing.T) {
+	useTempStore(t)
+	res, err := Create(CreateShareParams{FilePath: "a.txt", Password: "hunter22"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if _, err := Resolve(res.Share.Token, ""); !errors.Is(err, ErrPasswordRequired) {
+		t.Fatalf("expected ErrPasswordRequired, got %v", err)
+	}
+	if _, err := Resolve(res.Share.Token, "wrong"); !errors.Is(err, ErrWrongPassword) {
+		t.Fatalf("expected ErrWrongPassword, got %v", err)
+	}
+	got, err := Resolve(res.Share.Token, "hunter22")
+	if err != nil {
+		t.Fatalf("Resolve with correct password failed: %v", err)
+	}
+	if !got.PasswordProtected() {
+		t.Error("expected PasswordProtected true")
+	}
+	// Peek must work without the password but keep the hash out of reach of
+	// access bookkeeping (no count increment).
+	peeked, err := Peek(res.Share.Token)
+	if err != nil {
+		t.Fatalf("Peek failed: %v", err)
+	}
+	if peeked.AccessCount != 1 {
+		t.Errorf("Peek should not increment access count, got %d", peeked.AccessCount)
+	}
+}
+
+func TestListAndDelete(t *testing.T) {
+	useTempStore(t)
+	first, _ := Create(CreateShareParams{FilePath: "one.txt"})
+	second, _ := Create(CreateShareParams{FilePath: "two.txt"})
+
+	shares, err := List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(shares) != 2 {
+		t.Fatalf("expected 2 shares, got %d", len(shares))
+	}
+	if shares[0].ID != second.Share.ID {
+		t.Error("expected newest-first ordering")
+	}
+
+	if err := Delete(first.Share.ID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if err := Delete(first.Share.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound on double delete, got %v", err)
+	}
+	shares, _ = List()
+	if len(shares) != 1 || shares[0].ID != second.Share.ID {
+		t.Errorf("unexpected shares after delete: %+v", shares)
+	}
+}
+
+func TestPersistenceAcrossReload(t *testing.T) {
+	path := useTempStore(t)
+	res, err := Create(CreateShareParams{FilePath: "keep.txt"})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Simulate process restart: drop cache, same file.
+	ResetForTesting(path)
+	got, err := Resolve(res.Share.Token, "")
+	if err != nil {
+		t.Fatalf("Resolve after reload failed: %v", err)
+	}
+	if got.FilePath != "keep.txt" {
+		t.Errorf("unexpected share after reload: %+v", got)
+	}
+
+	// File must be 0600 — it holds tokens and password hashes.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat shares file: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("expected shares file mode 0600, got %o", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
Closes #1338

## What

"Send grandma the photo album": tokenized public links for any file or folder, optionally password-protected, optionally expiring, with a management UI.

- **File browser** → ⋮ menu → **Share link** → pick expiry (1h / 1d / 7d / 30d / never), optional password → copy the link.
- Recipient opens the link and gets the file (folders arrive as a zip). No account, no app.
- **Settings → Share Links** lists every link with expiry state, access count, copy, and revoke.

## Design notes (this was the "needs design" part)

**Storage** — `pkg/util/shareutil` persists to `shares.json` in the data dir (0600, atomic temp+rename writes), following the `settingsutil` pattern. Per AGENTS.md the DB is a last resort, and a small rebuildable JSON file is plenty here. Business logic lives in `pkg/util/` with the Params/Result pattern; handlers only do HTTP.

**Public surface** — new namespace `/api/v1/public/shares/:token` (+ `/info`), exempted from session auth by prefix in the middleware. The token is the credential: 32 random bytes hex (same generator as session tokens), passwords hashed with bcrypt like user passwords.

**Hardening choices:**
- Public endpoints go through the existing per-IP auth rate limiter, so share-password guessing is throttled the same way login is (on top of bcrypt cost).
- Downloads are always served `Content-Disposition: attachment` with `X-Content-Type-Options: nosniff` and `Content-Security-Policy: sandbox` — a shared `.html` file can never execute on the app's origin (the API host also serves the authenticated Flutter app, so inline rendering would be a stored-XSS vector).
- The `/info` endpoint withholds the target's name/size on password-protected shares until the correct password is supplied.
- Expired links return 410 Gone (distinct from 404) so recipients see "link expired" rather than "never existed"; expired shares stay visible to the owner in Settings until revoked.
- `PasswordHash` and the raw token never appear in management API responses (the token only appears embedded in the share URL, which the owner needs anyway).
- Share creation validates the target through `StatFile`, which runs the existing `safeJoin` traversal guard before anything is persisted.

**Trade-offs / follow-ups:**
- Share tokens appear in URL paths and therefore in access logs — same trade-off as the existing `?token=` auth (#1332); fine for a home server, worth revisiting if log shipping ever becomes a thing.
- No public landing page yet — the link is a direct download. The `/info` endpoint exists so a future lightweight landing page (filename, size, password prompt) can be built without API changes.
- Single-user semantics for now; when #350 lands, shares should grow an owner field.

## Testing

- `shareutil` unit tests: CRUD, expiry, password flow, persistence across restart, file mode.
- Handler integration tests (fake device detector, temp store): full lifecycle, folder zip, 401/403/410 paths, name non-disclosure on protected shares, traversal rejection on create.
- `make test` (Go + Flutter, all green), `flutter analyze` clean, `go vet` clean.

Manual verification of the UI dialog/settings card on a running instance is the one thing I couldn't do here — worth a click-through before merge.